### PR TITLE
chore(claude-code-proxy): Translate Korean text to English

### DIFF
--- a/ai-coding-assistants/claude-code-proxy-on-aws/CLAUDE.md
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/CLAUDE.md
@@ -81,4 +81,4 @@ If code, migration, and docs disagree, trust code and migration, then fix docs.
 Record repeated agent mistakes in this section. If the same avoidable mistake happens twice, add a dated bullet here with the symptom, the correct rule, and where to look next time. Record it here, not in a separate note.
 
 - Add new entries below this line.
-- 2026-04-05: 코드 리뷰 시 에러 경로를 끝까지 추적하지 않고 조기 종료하는 오류. `sync/services.py`에서 rollback 이후 `update_run_by_id(FAILED)`로 정상 처리되는 코드를 보지 않고 "STARTED row가 영구 잔류"라고 잘못 보고함. **규칙**: 에러 경로 리뷰 시 rollback/catch 이후 코드까지 반드시 완전히 추적할 것. "문제를 발견했다"는 확신이 생겨도 해당 코드 블록 끝까지 읽을 것.
+- 2026-04-05: Prematurely terminated error-path review without tracing to the end. In `sync/services.py`, failed to see that `update_run_by_id(FAILED)` correctly handles the state after rollback, and incorrectly reported "STARTED row persists permanently." **Rule**: When reviewing error paths, always trace completely through code after rollback/catch. Even when confident a bug has been found, read to the end of the code block.

--- a/ai-coding-assistants/claude-code-proxy-on-aws/README.md
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/README.md
@@ -1,142 +1,143 @@
 # Claude Code Proxy on AWS
 
-Claude Code 호환 프록시 서비스. IAM Identity Center(SSO)로 인증된 사용자에게 가상 API 키를 발급하고, 정책 엔진을 거쳐 Amazon Bedrock으로 요청을 라우팅합니다.
+An Anthropic-compatible proxy service on AWS. Issues virtual API keys to users authenticated via IAM Identity Center (SSO), routes requests through a policy engine, and forwards them to Amazon Bedrock.
 
-## 아키텍처
+## Architecture
 
 ![Architecture](assets/images/architecture.jpg)
 
-## 주요 기능
+## Key Features
 
-- SSO 인증 기반 가상 API 키 발급 및 자동 재사용
-- 8단계 정책 체인 엔진 (사용자/팀/모델/예산 정책 평가)
-- Anthropic Messages API ↔ Bedrock Converse API 실시간 변환
-- 모델 별칭 매핑 및 폴백 라우팅
-- 스트리밍/논스트리밍 추론 지원
-- 팀·사용자·모델별 예산 관리 및 사용량 추적
-- IAM Identity Center 사용자 동기화
-- ECS init container 기반 자동 DB 마이그레이션
-- AWS CDK 기반 원클릭 배포
+- SSO authentication-based virtual API key issuance with automatic reuse
+- 8-stage policy chain engine (user/team/model/budget policy evaluation)
+- Real-time Anthropic Messages API ↔ Bedrock Converse API translation
+- Model alias mapping and fallback routing
+- Streaming and non-streaming inference support
+- Per-team, per-user, and per-model budget management and usage tracking
+- IAM Identity Center user synchronization
+- Automatic DB migration via ECS init container
+- One-click deployment with AWS CDK
 
-## 주요 컴포넌트
+## Key Components
 
-| 컴포넌트 | 위치 | 역할 |
-|----------|------|------|
-| Gateway | `gateway/` | FastAPI 앱. Runtime(추론), Auth(키 발급), Admin(관리), Sync(동기화) API |
-| Shared | `shared/` | ORM 모델, 공용 응답/입력 스키마, 예외, KMS/해싱 유틸리티 |
-| Migrations | `migrations/` | Alembic DB 마이그레이션 (ECS init container로 실행) |
-| Infrastructure | `infra/` | AWS CDK 앱 (`FoundationStack`, `ServiceStack`) 및 supporting constructs |
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Gateway | `gateway/` | FastAPI app. Runtime (inference), Auth (key issuance), Admin (management), Sync (synchronization) APIs |
+| Shared | `shared/` | ORM models, shared request/response schemas, exceptions, KMS/hashing utilities |
+| Migrations | `migrations/` | Alembic DB migrations (executed via ECS init container) |
+| Infrastructure | `infra/` | AWS CDK app (`FoundationStack`, `ServiceStack`) and supporting constructs |
 
-## 디렉토리 구조
+## Directory Structure
 
 ```
 claude-code-proxy-on-aws/
-├── gateway/                        # FastAPI 애플리케이션
-│   ├── main.py                     # 앱 진입점, 라우터 등록
-│   ├── core/                       # 설정, DB, 미들웨어, 텔레메트리
+├── gateway/                        # FastAPI application
+│   ├── main.py                     # App entry point, router registration
+│   ├── core/                       # Config, DB, middleware, telemetry
 │   ├── domains/
-│   │   ├── auth/                   # SSO 인증, 가상 API 키 발급 (/v1/auth/token)
-│   │   ├── runtime/                # 추론 요청 처리 (/v1/messages)
-│   │   │   └── converter/          # Anthropic ↔ Bedrock API 변환 로직
-│   │   ├── policy/                 # 8단계 정책 체인 엔진
-│   │   │   └── handlers/           # 개별 정책 핸들러 (사용자/팀/모델/예산 등)
-│   │   ├── admin/                  # 관리 API (/v1/admin/*)
-│   │   ├── sync/                   # IAM Identity Center 사용자 동기화
-│   │   └── usage/                  # 사용량 집계 및 메트릭
-│   └── repositories/               # DB 접근 계층 (SQLAlchemy)
-├── shared/                         # 공용 모듈 (gateway + migrations 공유)
-│   ├── models/                     # ORM 모델 (User, Team, VirtualKey, ModelCatalog 등)
-│   ├── schemas/                    # Pydantic 입출력 스키마
-│   ├── utils/                      # KMS 암호화, 해싱, 상수
-│   └── exceptions.py               # 공용 예외 클래스
-├── migrations/                     # Alembic DB 마이그레이션
-│   └── versions/                   # 버전별 마이그레이션 스크립트
-├── infra/                          # AWS CDK 인프라 코드
-│   ├── app.py                      # CDK 앱 진입점
-│   ├── config.py                   # 환경별 설정 (InfraContext)
+│   │   ├── auth/                   # SSO auth, virtual API key issuance (/v1/auth/token)
+│   │   ├── runtime/                # Inference request handling (/v1/messages)
+│   │   │   └── converter/          # Anthropic ↔ Bedrock API translation logic
+│   │   ├── policy/                 # 8-stage policy chain engine
+│   │   │   └── handlers/           # Individual policy handlers (user/team/model/budget, etc.)
+│   │   ├── admin/                  # Admin API (/v1/admin/*)
+│   │   ├── sync/                   # IAM Identity Center user synchronization
+│   │   └── usage/                  # Usage aggregation and metrics
+│   └── repositories/               # DB access layer (SQLAlchemy)
+├── shared/                         # Shared modules (used by both gateway and migrations)
+│   ├── models/                     # ORM models (User, Team, VirtualKey, ModelCatalog, etc.)
+│   ├── schemas/                    # Pydantic input/output schemas
+│   ├── utils/                      # KMS encryption, hashing, constants
+│   └── exceptions.py               # Shared exception classes
+├── migrations/                     # Alembic DB migrations
+│   └── versions/                   # Per-version migration scripts
+├── infra/                          # AWS CDK infrastructure code
+│   ├── app.py                      # CDK app entry point
+│   ├── config.py                   # Per-environment config (InfraContext)
 │   ├── stacks/                     # FoundationStack, ServiceStack
 │   └── cdk_constructs/             # Network, Data, Compute, ALB, API, Observability
 ├── tests/
-│   ├── unit/gateway/               # Gateway 단위 테스트
-│   ├── unit/shared/                # Shared 단위 테스트
-│   └── test_*_stack.py             # CDK 스냅샷 테스트
+│   ├── unit/gateway/               # Gateway unit tests
+│   ├── unit/shared/                # Shared unit tests
+│   └── test_*_stack.py             # CDK snapshot tests
 ├── scripts/
-│   ├── deploy.sh                   # CDK 배포 스크립트 (대화형)
-│   ├── api_key_helper.sh           # Claude Code용 SigV4 키 발급 helper
-│   ├── local-bootstrap.py          # 로컬 개발 시드 데이터 삽입
-│   └── local-entrypoint.sh         # Docker 로컬 시작 스크립트
+│   ├── deploy.sh                   # CDK deployment script (interactive)
+│   ├── api_key_helper.sh           # SigV4 key issuance helper for Claude Code
+│   ├── local-bootstrap.py          # Local development seed data insertion
+│   └── local-entrypoint.sh         # Docker local startup script
 ├── assets/
-│   ├── grafana_dashboard.json      # Grafana 대시보드 정의
-│   └── observability/              # 로컬 O11y compose override용 설정
-├── Dockerfile                      # 게이트웨이 컨테이너 이미지
-├── docker-compose.yml              # 기본 로컬 개발 환경 (PostgreSQL + gateway)
-└── docker-compose.observability.yml # 선택형 로컬 O11y (OTel + Prometheus + Grafana)
+│   ├── grafana_dashboard.json      # Grafana dashboard definition
+│   └── observability/              # Local O11y compose override configs
+├── Dockerfile                      # Gateway container image
+├── docker-compose.yml              # Default local dev environment (PostgreSQL + gateway)
+└── docker-compose.observability.yml # Optional local O11y (OTel + Prometheus + Grafana)
 ```
 
-## 로컬 테스트
+## Local Testing
 
-### 사전 요구사항
+### Prerequisites
 
 - Docker & Docker Compose
 - AWS CLI v2 (`aws --version`)
-- Bedrock 모델 접근 권한이 있는 AWS 계정 및 SSO 프로필
+- An AWS account with Bedrock model access and an SSO profile
 
-### 1. AWS SSO 로그인
+### 1. AWS SSO Login
 
-로컬 게이트웨이가 Bedrock을 호출하려면 유효한 AWS 자격증명이 필요합니다.
+The local gateway requires valid AWS credentials to call Bedrock.
 
 ```bash
 aws sso login --profile <your-profile>
 ```
 
-### 2. AWS 프로필 설정 (선택)
+### 2. AWS Profile Configuration (Optional)
 
-SSO 프로필이 `default`가 아닌 경우, 프로젝트 루트에 `.env.local` 파일을 생성합니다.
+If your SSO profile is not `default`, create a `.env.local` file in the project root.
 
 ```bash
 echo "AWS_PROFILE=<your-profile>" > .env.local
 ```
 
-> `.env.local`은 `.gitignore`에 포함되어 있으며, 없어도 게이트웨이는 정상 기동됩니다. 이 경우 boto3 기본 자격증명 체인(환경변수 → `~/.aws/credentials` → default 프로필)을 사용합니다.
+> `.env.local` is included in `.gitignore` and the gateway starts normally without it. In that case, the boto3 default credential chain (environment variables → `~/.aws/credentials` → default profile) is used.
 
-### 3. Docker Compose 실행
+### 3. Run Docker Compose
 
 ```bash
 docker compose up --build
 ```
 
-두 개의 서비스가 순서대로 기동됩니다:
+Two services start in order:
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  postgres:16                                            │
 │  ├─ DB: claude_proxy, user/pass: dev/dev                │
-│  └─ healthcheck 통과 후 gateway 기동 허용               │
+│  └─ Gateway starts after healthcheck passes             │
 ├─────────────────────────────────────────────────────────┤
 │  gateway (FastAPI)                                      │
-│  ├─ ~/.aws → /aws-config:ro 마운트 후                    │
-│  │  /tmp/app-home/.aws 로 복사 (SSO refresh writable)   │
-│  ├─ PostgreSQL 연결 대기 (최대 60초)                     │
-│  ├─ local-bootstrap.py 실행 (시드 데이터 삽입)           │
-│  │   ├─ 사용자: local-user                              │
-│  │   ├─ 모델: claude-opus-4-6 / sonnet-4-6 / haiku-4-5 │
-│  │   ├─ 별칭 매핑: 모델별 패턴 + * → sonnet 폴백         │
-│  │   ├─ 기본 프롬프트 캐싱: 5m                          │
-│  │   └─ 초기 ACTIVE 가상 키 시드                         │
-│  ├─ OTLP exporter 비활성화 (로컬 기본값)                 │
-│  └─ uvicorn :8000 시작                                  │
+│  ├─ Mounts ~/.aws → /aws-config:ro, then copies to     │
+│  │  /tmp/app-home/.aws (SSO refresh writable)           │
+│  ├─ Waits for PostgreSQL connection (up to 60s)         │
+│  ├─ Runs local-bootstrap.py (seed data insertion)       │
+│  │   ├─ User: local-user                               │
+│  │   ├─ Models: claude-opus-4-6 / sonnet-4-6 / haiku-4-5│
+│  │   ├─ Alias mappings: per-model patterns + * → sonnet │
+│  │   │   fallback                                       │
+│  │   ├─ Default prompt caching: 5m                      │
+│  │   └─ Initial ACTIVE virtual key seed                 │
+│  ├─ OTLP exporter disabled (local default)              │
+│  └─ uvicorn :8000 starts                               │
 └─────────────────────────────────────────────────────────┘
 ```
 
-게이트웨이가 정상 기동되면 다음 로그가 출력됩니다:
+When the gateway starts successfully, the following log appears:
 
 ```
 gateway-1 | INFO:     Uvicorn running on http://0.0.0.0:8000
 ```
 
-### 선택: Observability 포함 실행
+### Optional: Run with Observability
 
-Prometheus/Grafana까지 함께 검증하려면 override compose를 추가로 사용합니다.
+To also verify Prometheus/Grafana, use the override compose file.
 
 ```bash
 docker compose \
@@ -145,13 +146,13 @@ docker compose \
   up --build
 ```
 
-추가로 다음 서비스가 함께 기동됩니다:
+The following additional services start:
 
-- `otel-collector`: gateway의 OTLP gRPC 메트릭 수신 후 Prometheus 형식으로 노출
-- `prometheus`: collector의 `/metrics` scrape
-- `grafana`: Prometheus datasource와 기본 대시보드 자동 로드
+- `otel-collector`: Receives OTLP gRPC metrics from the gateway and exposes them in Prometheus format
+- `prometheus`: Scrapes the collector's `/metrics` endpoint
+- `grafana`: Auto-loads Prometheus datasource and default dashboard
 
-접속 주소:
+Access URLs:
 
 - Gateway: `http://localhost:8000`
 - OTEL Collector metrics: `http://localhost:9464/metrics`
@@ -160,17 +161,17 @@ docker compose \
 
 ![Grafana Dashboard](assets/images/dashboard.jpg)
 
-Grafana는 시작 시 기본 datasource와 로컬 provisioning용 대시보드 [`assets/observability/grafana/dashboard.local.json`](/Users/jungseob/workspace/claude-code-proxy-on-aws/assets/observability/grafana/dashboard.local.json)을 자동으로 불러옵니다. 원본 import용 대시보드는 [`assets/grafana_dashboard.json`](/Users/jungseob/workspace/claude-code-proxy-on-aws/assets/grafana_dashboard.json)에 유지됩니다.
+On startup, Grafana automatically loads the default datasource and the local provisioning dashboard [`assets/observability/grafana/dashboard.local.json`](assets/observability/grafana/dashboard.local.json). The original importable dashboard is maintained at [`assets/grafana_dashboard.json`](assets/grafana_dashboard.json).
 
-주의사항:
+Notes:
 
-- Gateway 비즈니스 메트릭은 주로 runtime 요청 처리 경로에서 발생합니다. `GET /v1/healthz`만 호출해서는 대시보드가 비어 있을 수 있습니다.
-- 기본 OTLP export 주기는 60초이지만, `docker-compose.observability.yml`에서는 로컬 확인 편의를 위해 30초(`OTLP_EXPORT_INTERVAL_MILLIS=30000`)로 낮춰 둡니다.
-- 로컬 O11y 모드에서는 `POST /v1/messages` 호출 후 Prometheus/Grafana에 반영되기까지 최대 30초 정도 지연될 수 있습니다.
+- Gateway business metrics are primarily generated in the runtime request processing path. Calling only `GET /v1/healthz` may result in an empty dashboard.
+- The default OTLP export interval is 60 seconds, but `docker-compose.observability.yml` lowers it to 30 seconds (`OTLP_EXPORT_INTERVAL_MILLIS=30000`) for local verification convenience.
+- In local O11y mode, there may be up to a 30-second delay before `POST /v1/messages` calls are reflected in Prometheus/Grafana.
 
-### 4. Claude Code 연결
+### 4. Connect Claude Code
 
-`settings.local.json`을 참고하여 Claude Code 설정을 구성합니다.
+Configure Claude Code settings by referring to `settings.local.json`.
 
 ```json
 {
@@ -183,14 +184,14 @@ Grafana는 시작 시 기본 datasource와 로컬 provisioning용 대시보드 [
 }
 ```
 
-- `apiKeyHelper`는 로컬 게이트웨이의 `/v1/auth/token`을 호출해 현재 Virtual Key를 stdout으로 출력합니다.
-- `CLAUDE_CODE_API_KEY_HELPER_TTL_MS=60000`은 Claude Code가 1분마다 helper를 다시 실행하게 합니다.
-- 로컬 게이트웨이는 기본적으로 `VIRTUAL_KEY_TTL_MS=300000`(5분)으로 실행되어, helper 재호출과 만료 후 자동 refresh를 로컬에서도 재현할 수 있습니다.
-- `ANTHROPIC_BASE_URL`은 로컬 게이트웨이 주소를 가리킵니다.
+- `apiKeyHelper` calls the local gateway's `/v1/auth/token` and outputs the current Virtual Key to stdout.
+- `CLAUDE_CODE_API_KEY_HELPER_TTL_MS=60000` causes Claude Code to re-run the helper every 1 minute.
+- The local gateway runs with `VIRTUAL_KEY_TTL_MS=300000` (5 minutes) by default, allowing you to reproduce helper re-invocation and post-expiry auto-refresh locally.
+- `ANTHROPIC_BASE_URL` points to the local gateway address.
 
-> `apiKeyHelper` 경로는 절대 경로로 지정해야 합니다. `scripts/api_key_helper.local.sh`에 실행 권한(`chmod +x`)이 필요합니다.
+> The `apiKeyHelper` path must be an absolute path. `scripts/api_key_helper.local.sh` requires execute permission (`chmod +x`).
 
-### 5. 동작 확인
+### 5. Verify
 
 ```bash
 curl -s http://localhost:8000/v1/healthz
@@ -201,39 +202,39 @@ curl -s http://localhost:8000/v1/models \
   -H "x-api-key: ${LOCAL_KEY}" | python3 -m json.tool
 ```
 
-### 로컬 환경 특이사항
+### Local Environment Differences
 
-| 항목 | 프로덕션 | 로컬 |
-|------|---------|------|
-| 인증 | SigV4 → IAM → SSO 사용자 조회 | local helper → `/v1/auth/token` (`local-user` principal) |
-| KMS | AWS KMS 암호화/복호화 | `ENVIRONMENT=local` + `KMS_KEY_ID=local-dev-placeholder`일 때만 로컬 reversible fallback |
-| DB 마이그레이션 | Alembic (ECS init container) | Alembic `upgrade head` 후 bootstrap에서 `Base.metadata.create_all`로 보완 |
-| 모델 라우팅 | 모델별 별칭 매핑 | `claude-opus-4-6*`, `claude-sonnet-4-6*`, `claude-haiku-4-5*`, `*` → Sonnet 4.6 폴백 |
-| Observability | ADOT sidecar → Amazon Managed Prometheus | 기본 비활성화, override compose로 로컬 OTel/Prometheus/Grafana 선택 기동 |
-| AWS 자격증명 | ECS Task IAM Role | 호스트 `~/.aws`를 읽기 전용으로 마운트한 뒤 컨테이너 writable home으로 복사 |
+| Item | Production | Local |
+|------|-----------|-------|
+| Auth | SigV4 → IAM → SSO user lookup | local helper → `/v1/auth/token` (`local-user` principal) |
+| KMS | AWS KMS encrypt/decrypt | Local reversible fallback only when `ENVIRONMENT=local` + `KMS_KEY_ID=local-dev-placeholder` |
+| DB Migration | Alembic (ECS init container) | Alembic `upgrade head` followed by `Base.metadata.create_all` in bootstrap |
+| Model Routing | Per-model alias mapping | `claude-opus-4-6*`, `claude-sonnet-4-6*`, `claude-haiku-4-5*`, `*` → Sonnet 4.6 fallback |
+| Observability | ADOT sidecar → Amazon Managed Prometheus | Disabled by default, optionally start local OTel/Prometheus/Grafana via override compose |
+| AWS Credentials | ECS Task IAM Role | Host `~/.aws` mounted read-only, then copied to container writable home |
 
-## AWS 배포 및 테스트
+## AWS Deployment and Testing
 
-### 사전 요구사항
+### Prerequisites
 
 - AWS CLI v2, CDK CLI, Docker, [uv](https://docs.astral.sh/uv/), jq
-- Bedrock 모델 접근 권한이 있는 AWS 계정
-- IAM Identity Center(SSO) 활성화
+- An AWS account with Bedrock model access
+- IAM Identity Center (SSO) enabled
 
-### 0. 환경변수 설정
+### 0. Set Environment Variables
 
-이후 모든 단계에서 공통으로 사용할 환경변수를 먼저 설정합니다.
+Set the common environment variables used in all subsequent steps.
 
 ```bash
-export AWS_PROFILE=<your-profile>        # SSO 프로필 이름
-export AWS_REGION=<region>               # 예: ap-northeast-2
-export API_GW_ID=<your-api-id>           # cdk-outputs.json의 API Gateway ID
-export RUNTIME_BASE_URL=<http-or-https>://<your-runtime-host>  # ALB DNS 또는 커스텀 도메인
+export AWS_PROFILE=<your-profile>        # SSO profile name
+export AWS_REGION=<region>               # e.g., ap-northeast-2
+export API_GW_ID=<your-api-id>           # API Gateway ID from cdk-outputs.json
+export RUNTIME_BASE_URL=<http-or-https>://<your-runtime-host>  # ALB DNS or custom domain
 
-# SigV4 서명용 임시 자격증명 (Admin API 호출 시마다 만료 전 재실행)
+# Temporary credentials for SigV4 signing (re-run before expiry for each Admin API call)
 eval "$(aws configure export-credentials --format env)"
 
-# Admin API URL 및 공통 SigV4 옵션
+# Admin API URL and common SigV4 options
 API_URL="https://${API_GW_ID}.execute-api.${AWS_REGION}.amazonaws.com/prod"
 SIGV4_OPTS=(
   --aws-sigv4 "aws:amz:${AWS_REGION}:execute-api"
@@ -243,29 +244,29 @@ SIGV4_OPTS=(
 )
 ```
 
-### 1. 배포
+### 1. Deploy
 
 ```bash
 aws sso login --profile ${AWS_PROFILE}
 ./scripts/deploy.sh
 ```
 
-배포 스크립트가 리전 선택, Identity Store 설정, ACM 인증서, CDK 부트스트랩을 대화형으로 안내합니다. 배포 완료 후 API Gateway ID와 ALB DNS가 `cdk-outputs.json`에 출력됩니다. 해당 값으로 0단계 환경변수를 채워주세요.
+The deployment script interactively guides you through region selection, Identity Store configuration, ACM certificate, and CDK bootstrap. After deployment, the API Gateway ID and ALB DNS are output to `cdk-outputs.json`. Use those values to fill in the Step 0 environment variables.
 
-### 2. Identity Center 사용자 동기화
+### 2. Sync Identity Center Users
 
-IAM Identity Center의 사용자를 게이트웨이 DB에 동기화합니다.
+Synchronize IAM Identity Center users to the gateway DB.
 
 ```bash
 curl -s -X POST "$API_URL/v1/admin/sync/identity-center" \
   "${SIGV4_OPTS[@]}" | python3 -m json.tool
 ```
 
-동기화가 완료되어야 Identity Center 사용자가 `/v1/auth/token`에서 가상 API 키를 발급받을 수 있습니다. 이 단계를 건너뛰면 helper 호출은 `user_not_synced`로 실패합니다. 새 사용자가 추가되거나 퇴사자가 발생하면 동기화를 다시 실행하세요.
+Synchronization must complete before Identity Center users can obtain virtual API keys from `/v1/auth/token`. Skipping this step causes helper calls to fail with `user_not_synced`. Re-run the sync when new users are added or users leave the organization.
 
-### 3. 모델 등록
+### 3. Register Models
 
-Bedrock에서 사용할 모델 3개를 카탈로그에 등록합니다. 각 응답의 `"id"` 값을 다음 단계에서 사용합니다.
+Register the 3 models to use with Bedrock in the catalog. Use the `"id"` value from each response in the next step.
 
 ```bash
 # Claude Sonnet 4.6
@@ -301,18 +302,18 @@ curl -s -X POST "$API_URL/v1/admin/models" "${SIGV4_OPTS[@]}" \
   }' | python3 -m json.tool
 ```
 
-`bedrock_region`을 지정하면 모델별로 서로 다른 Bedrock Runtime 리전을 사용할 수 있습니다. 값을 생략하면 게이트웨이의 기본 `AWS_REGION`을 사용합니다.
+Specifying `bedrock_region` allows each model to use a different Bedrock Runtime region. If omitted, the gateway's default `AWS_REGION` is used.
 
-### 4. 모델 가격 등록
+### 4. Register Model Pricing
 
-모델별 가격 정보를 등록합니다. 가격이 없으면 추론 요청 시 `Active pricing is required` 오류가 발생합니다.
+Register pricing information for each model. Without pricing, inference requests will fail with an `Active pricing is required` error.
 
 ```bash
-SONNET_ID="<3단계 Sonnet 응답의 id>"
-OPUS_ID="<3단계 Opus 응답의 id>"
-HAIKU_ID="<3단계 Haiku 응답의 id>"
+SONNET_ID="<Sonnet id from Step 3 response>"
+OPUS_ID="<Opus id from Step 3 response>"
+HAIKU_ID="<Haiku id from Step 3 response>"
 
-# Claude Sonnet 4.6 가격
+# Claude Sonnet 4.6 pricing
 curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
   -d "{
     \"model_id\": \"$SONNET_ID\",
@@ -324,7 +325,7 @@ curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
     \"effective_from\": \"2025-01-01T00:00:00Z\"
   }" | python3 -m json.tool
 
-# Claude Opus 4.6 가격
+# Claude Opus 4.6 pricing
 curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
   -d "{
     \"model_id\": \"$OPUS_ID\",
@@ -336,7 +337,7 @@ curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
     \"effective_from\": \"2025-01-01T00:00:00Z\"
   }" | python3 -m json.tool
 
-# Claude Haiku 4.5 가격
+# Claude Haiku 4.5 pricing
 curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
   -d "{
     \"model_id\": \"$HAIKU_ID\",
@@ -349,9 +350,9 @@ curl -s -X POST "$API_URL/v1/admin/model-pricing" "${SIGV4_OPTS[@]}" \
   }" | python3 -m json.tool
 ```
 
-### 5. 별칭 매핑 등록
+### 5. Register Alias Mappings
 
-Claude Code가 요청하는 모델 이름 패턴을 등록된 모델로 연결합니다.
+Map the model name patterns requested by Claude Code to the registered models.
 
 ```bash
 # claude-sonnet-4-6* → Sonnet 4.6
@@ -366,16 +367,16 @@ curl -s -X POST "$API_URL/v1/admin/model-mappings" "${SIGV4_OPTS[@]}" \
 curl -s -X POST "$API_URL/v1/admin/model-mappings" "${SIGV4_OPTS[@]}" \
   -d "{\"selected_model_pattern\": \"claude-haiku-4-5*\", \"target_model_id\": \"$HAIKU_ID\", \"priority\": 10, \"is_fallback\": false}" | python3 -m json.tool
 
-# 폴백 매핑 (* → Sonnet 4.6, 매칭되지 않는 모든 요청에 적용)
+# Fallback mapping (* → Sonnet 4.6, applies to all unmatched requests)
 curl -s -X POST "$API_URL/v1/admin/model-mappings" "${SIGV4_OPTS[@]}" \
   -d "{\"selected_model_pattern\": \"*\", \"target_model_id\": \"$SONNET_ID\", \"priority\": 0, \"is_fallback\": true}" | python3 -m json.tool
 ```
 
-> `priority`가 높을수록 먼저 평가됩니다. 폴백 매핑은 `is_fallback: true`로 설정하고 가장 낮은 priority를 부여합니다.
+> Higher `priority` values are evaluated first. Set fallback mappings with `is_fallback: true` and assign the lowest priority.
 
-### 6. API Key Helper 설정
+### 6. API Key Helper Setup
 
-`scripts/settings.json`을 참고하여 Claude Code 설정을 구성합니다.
+Configure Claude Code settings by referring to `scripts/settings.json`.
 
 ```json
 {
@@ -386,59 +387,59 @@ curl -s -X POST "$API_URL/v1/admin/model-mappings" "${SIGV4_OPTS[@]}" \
 }
 ```
 
-- `ANTHROPIC_BASE_URL`은 API Gateway가 아니라 런타임을 받는 퍼블릭 ALB 또는 그 앞의 커스텀 도메인을 가리켜야 합니다.
-- ACM 인증서/커스텀 도메인이 없으면 `http://<AlbDnsName>`를 사용합니다.
-- `scripts/api_key_helper.sh`는 `POST /v1/auth/token`용 API Gateway 엔드포인트를 사용합니다.
-- 이 스크립트는 저장소 밖 `~/.claude` 같은 위치로 복사해 쓰는 것을 가정합니다.
-- 필요한 환경변수:
-  - `AWS_PROFILE`: SSO 프로필 이름 (기본값: `ccob`)
-  - `API_GW_ID`: 0단계에서 설정한 API Gateway ID
-  - `AWS_REGION`: 0단계에서 설정한 AWS 리전
+- `ANTHROPIC_BASE_URL` must point to the public ALB or custom domain that receives runtime traffic, not the API Gateway.
+- If no ACM certificate/custom domain is configured, use `http://<AlbDnsName>`.
+- `scripts/api_key_helper.sh` uses the API Gateway endpoint for `POST /v1/auth/token`.
+- This script is intended to be copied outside the repository to a location like `~/.claude`.
+- Required environment variables:
+  - `AWS_PROFILE`: SSO profile name (default: `ccob`)
+  - `API_GW_ID`: API Gateway ID set in Step 0
+  - `AWS_REGION`: AWS region set in Step 0
 
-첫 실행 시 helper가 SigV4 인증으로 가상 API 키를 자동 발급합니다.
+On first run, the helper automatically issues a virtual API key via SigV4 authentication.
 
 #### Virtual Key TTL
 
-- `VIRTUAL_KEY_TTL_MS`로 Virtual Key TTL을 밀리초 단위로 설정할 수 있습니다. 기본값은 `14400000`(4시간)이고, `0`이면 만료를 비활성화합니다.
-- 런타임 요청에서 키가 만료되면 게이트웨이는 `401 virtual_key_expired`를 반환합니다.
-- Claude Code는 401 이후 `apiKeyHelper`를 다시 실행해 새 키를 받아올 수 있습니다.
-- TTL 기반 자동 재발급은 **기존 `ACTIVE` key row를 업데이트**합니다.
-- 관리자 rotate는 **기존 row를 `ROTATED`로 남기고 새 `ACTIVE` row를 생성**합니다.
+- `VIRTUAL_KEY_TTL_MS` sets the Virtual Key TTL in milliseconds. The default is `14400000` (4 hours), and `0` disables expiration.
+- When a key expires during a runtime request, the gateway returns `401 virtual_key_expired`.
+- Claude Code can re-run `apiKeyHelper` after a 401 to obtain a new key.
+- TTL-based automatic reissuance **updates the existing `ACTIVE` key row**.
+- Admin rotation **marks the existing row as `ROTATED` and creates a new `ACTIVE` row**.
 
-원하면 Claude Code 설정에 `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`를 TTL보다 짧게 넣어 선행 재호출을 유도할 수 있지만, 이 값이 없어도 401 기반 재실행으로 동작합니다.
+You can optionally set `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` in Claude Code settings to a value shorter than the TTL to trigger proactive re-invocation, but even without it, 401-based re-execution works.
 
-### 7. 동작 확인
+### 7. Verify
 
 ```bash
-# 헬스체크
+# Health check
 curl -s "$RUNTIME_BASE_URL/v1/healthz"
 # {"status":"ok"}
 
-# 모델 목록 (등록된 매핑 확인)
+# Model list (verify registered mappings)
 curl -s "$RUNTIME_BASE_URL/v1/models" \
   -H "x-api-key: <your-api-key>" | python3 -m json.tool
 ```
 
-### 8. Claude Code 실행
+### 8. Run Claude Code
 
-설정이 완료되면 Claude Code를 실행하여 게이트웨이가 정상 동작하는지 확인합니다.
+Once configuration is complete, run Claude Code to verify the gateway is working correctly.
 
-### 9. 스택 삭제
+### 9. Delete Stacks
 
 ```bash
 ./scripts/deploy.sh destroy
 ```
 
-## 문서
+## Documentation
 
-| 문서 | 내용 |
-|------|------|
-| [docs/README.md](./docs/README.md) | 문서 인덱스 |
-| [docs/SYSTEM_ARCHITECTURE.md](./docs/SYSTEM_ARCHITECTURE.md) | 시스템 아키텍처 |
-| [docs/API_SPEC.md](./docs/API_SPEC.md) | API 상세 스펙 |
-| [docs/DATA_MODEL.md](./docs/DATA_MODEL.md) | 데이터 모델 |
-| [docs/RUNTIME_TRANSLATION.md](./docs/RUNTIME_TRANSLATION.md) | Anthropic ↔ Bedrock 변환 규칙 |
+| Document | Description |
+|----------|-------------|
+| [docs/README.md](./docs/README.md) | Documentation index |
+| [docs/SYSTEM_ARCHITECTURE.md](./docs/SYSTEM_ARCHITECTURE.md) | System architecture |
+| [docs/API_SPEC.md](./docs/API_SPEC.md) | API specification |
+| [docs/DATA_MODEL.md](./docs/DATA_MODEL.md) | Data model |
+| [docs/RUNTIME_TRANSLATION.md](./docs/RUNTIME_TRANSLATION.md) | Anthropic ↔ Bedrock translation rules |
 
-## 라이선스
+## License
 
 This library is licensed under the Apache 2.0 License.

--- a/ai-coding-assistants/claude-code-proxy-on-aws/infra/README.md
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/infra/README.md
@@ -1,68 +1,68 @@
 # Infrastructure (AWS CDK)
 
-현재 CDK 앱은 2개 스택(`FoundationStack`, `ServiceStack`)과 supporting constructs로 구성됩니다. 배포 스크립트(`scripts/deploy.sh`) 대신 CDK CLI를 직접 사용할 때 참고하세요.
+The CDK app consists of 2 stacks (`FoundationStack`, `ServiceStack`) and supporting constructs. Refer to this guide when using the CDK CLI directly instead of the deployment script (`scripts/deploy.sh`).
 
-## 사전 요구사항
+## Prerequisites
 
 - Python 3.13 + [uv](https://docs.astral.sh/uv/)
 - Node.js + CDK CLI (`npm install -g aws-cdk`)
-- AWS 자격증명 설정 완료
-- Docker 실행 중 (컨테이너 이미지 빌드)
+- AWS credentials configured
+- Docker running (for container image builds)
 
-## 의존성 설치
+## Install Dependencies
 
 ```bash
-# 프로젝트 루트에서
+# From the project root
 uv sync --group dev --group infra
 ```
 
-## CDK 부트스트랩 (최초 1회)
+## CDK Bootstrap (First Time Only)
 
 ```bash
 cd infra
 cdk bootstrap
 ```
 
-## Synth (템플릿 생성만)
+## Synth (Template Generation Only)
 
 ```bash
 cd infra
 
-# HTTPS 사용 시 (ACM 인증서 필요)
+# With HTTPS (ACM certificate required)
 cdk synth \
   -c identity_store_id=d-1234567890 \
   -c acm_certificate_arn=<YOUR_ACM_CERTIFICATE_ARN>
 
-# HTTPS 없이 (HTTP만)
+# Without HTTPS (HTTP only)
 cdk synth -c identity_store_id=d-1234567890
 ```
 
-## 배포
+## Deploy
 
 ```bash
 cd infra
 
-# 스택 목록 확인
+# List stacks
 cdk list
 
-# 변경사항 확인
+# Review changes
 cdk diff
 
-# 전체 배포
+# Deploy all stacks
 cdk deploy --all \
   -c identity_store_id=d-1234567890 \
   --require-approval broadening
 
-# ACM 인증서 지정하여 배포
+# Deploy with ACM certificate
 cdk deploy --all \
   -c identity_store_id=d-1234567890 \
   -c acm_certificate_arn=<YOUR_ACM_CERTIFICATE_ARN> \
   --require-approval broadening
 ```
 
-## 환경별 배포
+## Environment-Specific Deployment
 
-`cdk.json`의 context를 오버라이드하여 다른 환경에 배포할 수 있습니다:
+Override `cdk.json` context to deploy to a different environment:
 
 ```bash
 cdk deploy --all \
@@ -71,15 +71,15 @@ cdk deploy --all \
   -c identity_store_id=d-1234567890
 ```
 
-`environment=prod`일 때 자동으로 적용되는 설정:
-- 로그 보존: 1주 → 1개월
-- Aurora 삭제 보호 활성화
-- 스냅샷 기반 삭제 정책
+Settings automatically applied when `environment=prod`:
+- Log retention: 1 week → 1 month
+- Aurora deletion protection enabled
+- Snapshot-based deletion policy
 
-## 스택 구조
+## Stack Structure
 
 ```
-FoundationStack    VPC, 서브넷, SG, VPC Endpoints, Aurora, KMS, Secrets Manager
+FoundationStack    VPC, Subnets, SGs, VPC Endpoints, Aurora, KMS, Secrets Manager
     |
     +-- ServiceStack       AMP, ECS Cluster, ECR, ALB, API Gateway
             |
@@ -87,17 +87,17 @@ FoundationStack    VPC, 서브넷, SG, VPC Endpoints, Aurora, KMS, Secrets Manag
             +-- GatewayTaskDefinition   ECS migrate/gateway-app/adot containers
 ```
 
-런타임 엔드포인트(`/v1/healthz`, `/v1/models`, `/v1/messages`)는 API Gateway를 거치지 않고 퍼블릭 ALB로 직접 들어갑니다.
+Runtime endpoints (`/v1/healthz`, `/v1/models`, `/v1/messages`) go directly to the public ALB without passing through API Gateway.
 
-## 주요 설정값 (cdk.json)
+## Key Configuration Values (cdk.json)
 
-| 키 | 기본값 | 설명 |
-|---|---|---|
-| `environment` | `dev` | 배포 환경 |
-| `region` | `ap-northeast-2` | AWS 리전 |
-| `app_name` | `claude-proxy` | 리소스 이름 접두사 |
-| `identity_store_id` | _(필수)_ | IAM Identity Center identity store ID |
+| Key | Default | Description |
+|-----|---------|-------------|
+| `environment` | `dev` | Deployment environment |
+| `region` | `ap-northeast-2` | AWS region |
+| `app_name` | `claude-proxy` | Resource name prefix |
+| `identity_store_id` | _(required)_ | IAM Identity Center identity store ID |
 | `vpc_cidr` | `10.0.0.0/16` | VPC CIDR |
-| `aurora_min_capacity` | `0.5` | Aurora Serverless 최소 ACU |
-| `aurora_max_capacity` | `1.0` | Aurora Serverless 최대 ACU |
-| `acm_certificate_arn` | _(없음)_ | ACM 인증서 ARN (없으면 HTTP만) |
+| `aurora_min_capacity` | `0.5` | Aurora Serverless minimum ACU |
+| `aurora_max_capacity` | `1.0` | Aurora Serverless maximum ACU |
+| `acm_certificate_arn` | _(none)_ | ACM certificate ARN (HTTP only if not provided) |

--- a/ai-coding-assistants/claude-code-proxy-on-aws/scripts/api_key_helper.local.sh
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/scripts/api_key_helper.local.sh
@@ -39,7 +39,7 @@ print(payload.get("virtual_key", {}).get("secret", ""))
 ')"
 
 if [[ -z "${TOKEN}" ]]; then
-  echo "ERROR: Local token service에서 키를 받지 못했습니다: ${RESPONSE}" >&2
+  echo "ERROR: Failed to retrieve key from local token service: ${RESPONSE}" >&2
   exit 1
 fi
 

--- a/ai-coding-assistants/claude-code-proxy-on-aws/scripts/api_key_helper.sh
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/scripts/api_key_helper.sh
@@ -8,9 +8,9 @@ TOKEN_SERVICE_URL="https://${API_GW_ID}.execute-api.${AWS_REGION}.amazonaws.com/
 
 if ! eval "$(aws configure export-credentials --profile ${AWS_PROFILE} --format env 2>/dev/null)"; then
   if [[ -n "${AWS_PROFILE}" ]]; then
-    echo "ERROR: aws sso login --profile ${AWS_PROFILE} 을 실행하세요" >&2
+    echo "ERROR: Run 'aws sso login --profile ${AWS_PROFILE}'" >&2
   else
-    echo "ERROR: aws sso login 을 실행하세요" >&2
+    echo "ERROR: Run 'aws sso login'" >&2
   fi
   exit 1
 fi
@@ -36,7 +36,7 @@ print(payload.get("virtual_key", {}).get("secret", ""))
 ' 2>/dev/null)"
 
 if [[ -z "${TOKEN}" ]]; then
-  echo "ERROR: Token Service에서 키를 받지 못했습니다: ${RESPONSE}" >&2
+  echo "ERROR: Failed to retrieve key from token service: ${RESPONSE}" >&2
   exit 1
 fi
 

--- a/ai-coding-assistants/claude-code-proxy-on-aws/scripts/bedrock-pricing.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/scripts/bedrock-pricing.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""AWS Bedrock Claude 모델 및 가격 조회. list_price_lists + CSV 방식."""
+"""AWS Bedrock Claude model and pricing lookup. Uses list_price_lists + CSV approach."""
 
 import argparse
 import json
@@ -25,7 +25,7 @@ EXCLUDE_KEYWORDS = [
     "lctx",
 ]
 
-# 기본 표시할 usageType (터미널 출력용)
+# Default usageTypes to display (for terminal output)
 DISPLAY_TYPES = [
     "InputTokenCount",
     "OutputTokenCount",
@@ -61,7 +61,7 @@ def normalize(model):
 
 
 def extract_usage_type(usage_type):
-    """usageType에서 핵심 타입 추출"""
+    """Extract core type from usageType."""
     # "USE1-MP:USE1_CacheReadInputTokenCount_Global-Units" -> "CacheReadInputTokenCount"
     match = re.search(
         r"((?:CacheRead|CacheWrite1h|CacheWrite)?(?:Input|Output|Response)TokenCount)",
@@ -120,7 +120,7 @@ def fetch_claude_pricing(verbose=False):
                 if any(kw in desc for kw in EXCLUDE_KEYWORDS):
                     continue
 
-                # usageType (14번째 컬럼, index 13)
+                # usageType (14th column, index 13)
                 usage_type_raw = cols[13] if len(cols) > 13 else ""
                 usage_type = extract_usage_type(usage_type_raw)
                 if not usage_type:
@@ -141,7 +141,7 @@ def fetch_claude_pricing(verbose=False):
                 if model not in pricing:
                     pricing[model] = {}
 
-                # 최저가 유지
+                # Keep lowest price
                 if usage_type not in pricing[model] or float(price) < float(
                     pricing[model][usage_type]
                 ):
@@ -151,9 +151,9 @@ def fetch_claude_pricing(verbose=False):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="AWS Bedrock Claude 가격 조회")
-    parser.add_argument("--json", action="store_true", help="JSON 출력")
-    parser.add_argument("--save", metavar="FILE", help="파일 저장")
+    parser = argparse.ArgumentParser(description="AWS Bedrock Claude pricing lookup")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--save", metavar="FILE", help="Save to file")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
 
@@ -174,7 +174,7 @@ def main():
         else:
             print(out)
     else:
-        # 헤더
+        # Header
         headers = ["Model"] + [
             t.replace("TokenCount", "").replace("Input", "In").replace("Output", "Out")
             for t in DISPLAY_TYPES

--- a/ai-coding-assistants/claude-code-proxy-on-aws/scripts/deploy.sh
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/scripts/deploy.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # ──────────────────────────────────────────────
-# Claude Code Proxy on AWS — 배포 스크립트
+# Claude Code Proxy on AWS — Deployment Script
 # ──────────────────────────────────────────────
 
 INFRA_DIR="$(cd "$(dirname "$0")/../infra" && pwd)"
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CDK_JSON="$INFRA_DIR/cdk.json"
 
-# 색상
+# Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -23,63 +23,63 @@ error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
 prompt() { echo -en "${CYAN}▸${NC} $*"; }
 
 # ──────────────────────────────────────────────
-# 1. 사전 요구사항 확인
+# 1. Check Prerequisites
 # ──────────────────────────────────────────────
 check_prerequisites() {
-    info "사전 요구사항 확인 중..."
+    info "Checking prerequisites..."
 
-    command -v aws >/dev/null 2>&1 || error "AWS CLI가 설치되어 있지 않습니다."
-    command -v cdk >/dev/null 2>&1 || error "CDK CLI가 설치되어 있지 않습니다. (npm install -g aws-cdk)"
-    command -v docker >/dev/null 2>&1 || error "Docker가 설치되어 있지 않습니다."
-    command -v uv >/dev/null 2>&1 || error "uv가 설치되어 있지 않습니다."
-    command -v jq >/dev/null 2>&1 || error "jq가 설치되어 있지 않습니다."
+    command -v aws >/dev/null 2>&1 || error "AWS CLI is not installed."
+    command -v cdk >/dev/null 2>&1 || error "CDK CLI is not installed. (npm install -g aws-cdk)"
+    command -v docker >/dev/null 2>&1 || error "Docker is not installed."
+    command -v uv >/dev/null 2>&1 || error "uv is not installed."
+    command -v jq >/dev/null 2>&1 || error "jq is not installed."
 
-    # Docker 실행 확인
-    docker info >/dev/null 2>&1 || error "Docker 데몬이 실행중이지 않습니다."
+    # Check Docker is running
+    docker info >/dev/null 2>&1 || error "Docker daemon is not running."
 
-    ok "사전 요구사항 확인 완료"
+    ok "All prerequisites satisfied"
 }
 
 # ──────────────────────────────────────────────
-# 2. AWS 인증 확인
+# 2. Check AWS Authentication
 # ──────────────────────────────────────────────
 check_aws_auth() {
-    info "AWS 인증 확인 중..."
+    info "Checking AWS authentication..."
 
     local identity
-    identity=$(aws sts get-caller-identity 2>/dev/null) || error "AWS 인증 실패. 'aws configure' 또는 'aws sso login'을 실행하세요."
+    identity=$(aws sts get-caller-identity 2>/dev/null) || error "AWS authentication failed. Run 'aws configure' or 'aws sso login'."
 
     local account
     account=$(echo "$identity" | jq -r '.Account')
 
-    ok "AWS 계정: $account"
+    ok "AWS Account: $account"
     export CDK_DEFAULT_ACCOUNT="$account"
 }
 
 # ──────────────────────────────────────────────
-# 3. 리전 선택
+# 3. Select Region
 # ──────────────────────────────────────────────
 select_region() {
     local current_region
     current_region=$(jq -r '.context.region // "ap-northeast-2"' "$CDK_JSON")
 
-    info "현재 설정된 리전: $current_region"
-    prompt "배포할 리전 [$current_region]: "
+    info "Current configured region: $current_region"
+    prompt "Deployment region [$current_region]: "
     read -er input_region
 
     local region="${input_region:-$current_region}"
 
     if [[ "$region" != "$current_region" ]]; then
         _set_cdk_context "region" "$region"
-        ok "리전 변경: $region"
+        ok "Region changed: $region"
     fi
 
     export CDK_DEFAULT_REGION="$region"
-    ok "배포 리전: $region"
+    ok "Deployment region: $region"
 }
 
 # ──────────────────────────────────────────────
-# 4. Identity Store ID 선택
+# 4. Select Identity Store ID
 # ──────────────────────────────────────────────
 select_identity_store_id() {
     local region current_id discovered_id
@@ -89,7 +89,7 @@ select_identity_store_id() {
     discovered_id=$(_discover_identity_store_id "$region")
 
     if [[ -n "$discovered_id" && "$current_id" != "$discovered_id" ]]; then
-        info "AWS에서 활성 Identity Store ID를 찾았습니다: $discovered_id (리전: ${DISCOVERED_IDENTITY_STORE_REGION:-$region})"
+        info "Found active Identity Store ID from AWS: $discovered_id (region: ${DISCOVERED_IDENTITY_STORE_REGION:-$region})"
     fi
 
     local default_id="$current_id"
@@ -101,25 +101,25 @@ select_identity_store_id() {
         prompt "Identity Store ID [$default_id]: "
         read -er input_id
     else
-        warn "활성 Identity Store ID를 자동으로 찾지 못했습니다."
-        info "직접 확인 명령: aws sso-admin list-instances --region <region> --query 'Instances[].IdentityStoreId' --output text"
+        warn "Could not automatically discover an active Identity Store ID."
+        info "Manual lookup: aws sso-admin list-instances --region <region> --query 'Instances[].IdentityStoreId' --output text"
         prompt "Identity Store ID: "
         read -er input_id
     fi
 
     local identity_store_id="${input_id:-$default_id}"
     if [[ -z "$identity_store_id" || "$identity_store_id" == "placeholder" ]]; then
-        error "Identity Store ID는 필수입니다. 올바른 값을 입력하세요."
+        error "Identity Store ID is required. Please enter a valid value."
     fi
 
     if [[ "$identity_store_id" != "$current_id" ]]; then
         _set_cdk_context "identity_store_id" "$identity_store_id"
-        ok "Identity Store ID 설정 완료: $identity_store_id"
+        ok "Identity Store ID configured: $identity_store_id"
     else
-        ok "Identity Store ID 유지: $identity_store_id"
+        ok "Identity Store ID unchanged: $identity_store_id"
     fi
 
-    # Identity Store 리전 설정
+    # Identity Store region configuration
     local current_region
     current_region=$(jq -r '.context.identity_store_region // empty' "$CDK_JSON")
     local default_region="${DISCOVERED_IDENTITY_STORE_REGION:-$current_region}"
@@ -128,11 +128,11 @@ select_identity_store_id() {
     fi
 
     if [[ "$default_region" != "$region" ]]; then
-        prompt "Identity Store 리전 [$default_region]: "
+        prompt "Identity Store region [$default_region]: "
         read -er input_region
         local identity_store_region="${input_region:-$default_region}"
         _set_cdk_context "identity_store_region" "$identity_store_region"
-        ok "Identity Store 리전 설정 완료: $identity_store_region"
+        ok "Identity Store region configured: $identity_store_region"
     else
         _set_cdk_context "identity_store_region" "$region"
     fi
@@ -162,7 +162,7 @@ _discover_identity_store_id() {
 
         if [[ "$count" -gt 1 ]]; then
             DISCOVERED_IDENTITY_STORE_REGION="$r"
-            warn "활성 IAM Identity Center 인스턴스가 여러 개입니다 (리전: $r)." >&2
+            warn "Multiple active IAM Identity Center instances found (region: $r)." >&2
             echo "$instances" | jq -r '
                 .[]
                 | "  - IdentityStoreId: \(.IdentityStoreId)\n    OwnerAccountId: \(.OwnerAccountId)\n    InstanceArn: \(.InstanceArn)"
@@ -171,36 +171,37 @@ _discover_identity_store_id() {
     done
 }
 
+
 # ──────────────────────────────────────────────
-# 5. ACM 인증서 확인/생성
+# 5. Check/Create ACM Certificate
 # ──────────────────────────────────────────────
 ensure_acm_certificate() {
-    info "ACM 인증서 확인 중..."
+    info "Checking ACM certificate..."
 
     local existing_arn
     existing_arn=$(jq -r '.context.acm_certificate_arn // empty' "$CDK_JSON")
 
     if [[ -n "$existing_arn" ]]; then
-        ok "ACM 인증서 설정됨: ${existing_arn:0:60}..."
+        ok "ACM certificate configured: ${existing_arn:0:60}..."
         return
     fi
 
-    warn "ACM 인증서가 cdk.json에 설정되어 있지 않습니다."
+    warn "No ACM certificate configured in cdk.json."
     echo ""
-    echo "  1) 기존 ACM 인증서 ARN 입력"
-    echo "  2) 새 ACM 인증서 생성 (도메인 필요)"
-    echo "  3) 건너뛰기 (HTTPS 없이 HTTP만 사용)"
+    echo "  1) Enter an existing ACM certificate ARN"
+    echo "  2) Create a new ACM certificate (domain required)"
+    echo "  3) Skip (deploy with HTTP only, no HTTPS)"
     echo ""
     while true; do
-        prompt "선택 [1/2/3]: "
+        prompt "Choose [1/2/3]: "
         read -er choice
         case "${choice}" in
             1)
-                prompt "ACM 인증서 ARN: "
+                prompt "ACM certificate ARN: "
                 read -er cert_arn
-                [[ -z "$cert_arn" ]] && { warn "인증서 ARN이 비어있습니다."; continue; }
+                [[ -z "$cert_arn" ]] && { warn "Certificate ARN is empty."; continue; }
                 _set_cdk_context "acm_certificate_arn" "$cert_arn"
-                ok "ACM 인증서 설정 완료"
+                ok "ACM certificate configured"
                 break
                 ;;
             2)
@@ -208,27 +209,27 @@ ensure_acm_certificate() {
                 break
                 ;;
             3)
-                warn "HTTPS 없이 배포합니다. ALB는 HTTP(80)만 사용합니다."
+                warn "Deploying without HTTPS. ALB will use HTTP(80) only."
                 _set_cdk_context "acm_certificate_arn" ""
                 export SKIP_HTTPS=true
                 break
                 ;;
             *)
-                warn "1, 2, 3 중에서 선택하세요."
+                warn "Please choose 1, 2, or 3."
                 ;;
         esac
     done
 }
 
 _create_acm_certificate() {
-    prompt "도메인 이름 (예: proxy.example.com): "
+    prompt "Domain name (e.g., proxy.example.com): "
     read -er domain
-    [[ -z "$domain" ]] && error "도메인이 비어있습니다."
+    [[ -z "$domain" ]] && error "Domain is empty."
 
     local region
     region=$(jq -r '.context.region // "ap-northeast-2"' "$CDK_JSON")
 
-    info "ACM 인증서 요청 중: $domain"
+    info "Requesting ACM certificate: $domain"
     local cert_arn
     cert_arn=$(aws acm request-certificate \
         --domain-name "$domain" \
@@ -237,10 +238,10 @@ _create_acm_certificate() {
         --query 'CertificateArn' \
         --output text)
 
-    ok "인증서 요청 완료: $cert_arn"
+    ok "Certificate request complete: $cert_arn"
     echo ""
-    warn "DNS 검증이 필요합니다."
-    info "검증 레코드 조회 중 (최대 30초 대기)..."
+    warn "DNS validation is required."
+    info "Fetching validation records (waiting up to 30 seconds)..."
 
     local validation_info=""
     local attempt
@@ -254,7 +255,7 @@ _create_acm_certificate() {
         if [[ -n "$validation_info" && "$validation_info" != "null" ]]; then
             break
         fi
-        info "검증 레코드 대기 중... (${attempt}/6)"
+        info "Waiting for validation records... (${attempt}/6)"
     done
 
     if [[ -n "$validation_info" && "$validation_info" != "null" ]]; then
@@ -262,28 +263,28 @@ _create_acm_certificate() {
         cname_name=$(echo "$validation_info" | jq -r '.Name')
         cname_value=$(echo "$validation_info" | jq -r '.Value')
         echo ""
-        echo -e "  ${CYAN}DNS에 아래 CNAME 레코드를 추가하세요:${NC}"
+        echo -e "  ${CYAN}Add the following CNAME record to your DNS:${NC}"
         echo -e "  Name:  ${GREEN}$cname_name${NC}"
         echo -e "  Value: ${GREEN}$cname_value${NC}"
         echo ""
     else
-        warn "검증 레코드를 가져오지 못했습니다. AWS 콘솔에서 직접 확인하세요: $cert_arn"
+        warn "Could not fetch validation records. Check the AWS console: $cert_arn"
     fi
 
-    prompt "DNS 레코드 추가 후 Enter를 눌러 검증을 기다립니다..."
+    prompt "Press Enter after adding the DNS record to wait for validation..."
     read -er
 
-    info "인증서 검증 대기 중 (최대 5분)..."
+    info "Waiting for certificate validation (up to 5 minutes)..."
     if aws acm wait certificate-validated \
         --certificate-arn "$cert_arn" \
         --region "$region" 2>/dev/null; then
-        ok "인증서 검증 완료!"
+        ok "Certificate validated!"
     else
-        warn "검증 대기 시간 초과. 배포를 계속하지만, 인증서 검증이 완료되어야 HTTPS가 동작합니다."
+        warn "Validation wait timed out. Deployment will continue, but HTTPS will not work until the certificate is validated."
     fi
 
     _set_cdk_context "acm_certificate_arn" "$cert_arn"
-    ok "cdk.json에 인증서 ARN 저장 완료"
+    ok "Certificate ARN saved to cdk.json"
 }
 
 _set_cdk_context() {
@@ -295,10 +296,10 @@ _set_cdk_context() {
 }
 
 # ──────────────────────────────────────────────
-# 6. CDK 부트스트랩
+# 6. CDK Bootstrap
 # ──────────────────────────────────────────────
 ensure_bootstrap() {
-    info "CDK 부트스트랩 확인 중..."
+    info "Checking CDK bootstrap..."
 
     local account region
     account="$CDK_DEFAULT_ACCOUNT"
@@ -322,47 +323,47 @@ ensure_bootstrap() {
     fi
 
     if [[ "$stack_status" == "NOT_FOUND" || "$stack_status" == *"ROLLBACK"* || "$current_version" -lt "$min_version" ]]; then
-        info "CDK 부트스트랩 실행 중... (현재 버전: $current_version, 필요 버전: $min_version+)"
+        info "Running CDK bootstrap... (current version: $current_version, required: $min_version+)"
         cd "$INFRA_DIR"
         cdk bootstrap "aws://$account/$region"
-        ok "CDK 부트스트랩 완료"
+        ok "CDK bootstrap complete"
     else
-        ok "CDK 부트스트랩 이미 완료 (버전: $current_version)"
+        ok "CDK bootstrap already done (version: $current_version)"
     fi
 }
 
 # ──────────────────────────────────────────────
-# 7. 의존성 설치
+# 7. Install Dependencies
 # ──────────────────────────────────────────────
 install_dependencies() {
-    info "Python 의존성 설치 중..."
+    info "Installing Python dependencies..."
     cd "$PROJECT_ROOT"
     uv sync --group dev --group infra
-    ok "의존성 설치 완료"
+    ok "Dependencies installed"
 }
 
 # ──────────────────────────────────────────────
-# 8. CDK 배포
+# 8. CDK Deploy
 # ──────────────────────────────────────────────
 deploy_stacks() {
     cd "$INFRA_DIR"
 
-    info "변경사항 확인 중..."
+    info "Reviewing changes..."
     echo ""
     cdk diff 2>&1 || true
     echo ""
 
     while true; do
-        prompt "위 변경사항을 배포하시겠습니까? [y/N]: "
+        prompt "Deploy the above changes? [y/N]: "
         read -er confirm
         case "${confirm}" in
             y|Y) break ;;
-            n|N|"") info "배포를 취소합니다."; exit 0 ;;
-            *) warn "y 또는 N을 입력하세요." ;;
+            n|N|"") info "Deployment cancelled."; exit 0 ;;
+            *) warn "Please enter y or N." ;;
         esac
     done
 
-    info "CDK 스택 배포 중... (Docker 빌드 포함, 수 분 소요될 수 있습니다)"
+    info "Deploying CDK stacks... (includes Docker build, may take several minutes)"
     echo ""
 
     cdk deploy --all \
@@ -370,55 +371,55 @@ deploy_stacks() {
         --no-path-metadata \
         --outputs-file "$PROJECT_ROOT/cdk-outputs.json"
 
-    ok "배포 완료!"
+    ok "Deployment complete!"
     echo ""
 
     if [[ -f "$PROJECT_ROOT/cdk-outputs.json" ]]; then
-        info "배포 결과:"
+        info "Deployment outputs:"
         jq '.' "$PROJECT_ROOT/cdk-outputs.json"
     fi
 }
 
 # ──────────────────────────────────────────────
-# 9. CDK 삭제
+# 9. CDK Destroy
 # ──────────────────────────────────────────────
 destroy_stacks() {
     cd "$INFRA_DIR"
 
-    warn "모든 CDK 스택을 삭제합니다."
+    warn "This will delete all CDK stacks."
     echo ""
-    echo "삭제될 스택:"
+    echo "Stacks to be deleted:"
     cdk list 2>/dev/null || true
     echo ""
 
     while true; do
-        prompt "정말 모든 스택을 삭제하시겠습니까? [y/N]: "
+        prompt "Are you sure you want to delete all stacks? [y/N]: "
         read -er confirm
         case "${confirm}" in
             y|Y) break ;;
-            n|N|"") info "삭제를 취소합니다."; exit 0 ;;
-            *) warn "y 또는 N을 입력하세요." ;;
+            n|N|"") info "Deletion cancelled."; exit 0 ;;
+            *) warn "Please enter y or N." ;;
         esac
     done
 
-    info "CDK 스택 삭제 중..."
+    info "Deleting CDK stacks..."
     cdk destroy --all --force
 
-    ok "모든 스택이 삭제되었습니다!"
+    ok "All stacks have been deleted!"
 
-    # cdk-outputs.json 삭제
+    # Delete cdk-outputs.json
     [[ -f "$PROJECT_ROOT/cdk-outputs.json" ]] && rm -f "$PROJECT_ROOT/cdk-outputs.json"
 }
 
 # ──────────────────────────────────────────────
-# 메인 실행
+# Main
 # ──────────────────────────────────────────────
 usage() {
     echo "Usage: $0 [command]"
     echo ""
     echo "Commands:"
-    echo "  deploy   배포 (기본값)"
-    echo "  destroy  모든 스택 삭제"
+    echo "  deploy   Deploy (default)"
+    echo "  destroy  Delete all stacks"
     echo ""
 }
 
@@ -454,7 +455,7 @@ main() {
             ensure_bootstrap
             deploy_stacks
             echo ""
-            ok "모든 배포가 완료되었습니다!"
+            ok "All deployment steps complete!"
             ;;
         destroy)
             check_prerequisites
@@ -467,10 +468,11 @@ main() {
             exit 0
             ;;
         *)
-            error "알 수 없는 명령: $command"
+            error "Unknown command: $command"
             ;;
     esac
     echo ""
 }
 
 main "$@"
+

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/scripts/test_api_key_helper_local.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/scripts/test_api_key_helper_local.py
@@ -81,6 +81,6 @@ def test_local_api_key_helper_surfaces_error_payloads(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert (
-        'ERROR: Local token service에서 키를 받지 못했습니다: '
+        'ERROR: Failed to retrieve key from local token service: '
         '{"error":{"code":"authentication_failed"}}'
     ) in result.stderr


### PR DESCRIPTION
## Summary

Translate all Korean content to English in the claude-code-proxy-on-aws directory for international GitHub audience readability.

## Changes

| File | What changed |
|------|-------------|
| README.md | Full project documentation (architecture, features, local testing, deployment guide) |
| CLAUDE.md | Agent mistake log entry |
| infra/README.md | CDK infrastructure guide |
| scripts/deploy.sh | All user-facing messages (prompts, errors, info) |
| scripts/api_key_helper.sh | Error messages |
| scripts/api_key_helper.local.sh | Error messages |
| scripts/bedrock-pricing.py | Docstrings, comments, argparse descriptions |
| tests/unit/scripts/test_api_key_helper_local.py | Assert string synced with updated shell script |

## Notes

- Translation only, no logic, structure, or behavior changes
- Shell script error messages and their corresponding test assertions are kept in sync
- Verified with grep that zero Korean characters remain
