### PR TITLE
feat. add bedrock request metadata

### DIFF
--- a/ai-coding-assistants/claude-code-proxy-on-aws/docs/API_SPEC.md
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/docs/API_SPEC.md
@@ -166,7 +166,8 @@ Extra top-level request fields are accepted by validation but ignored unless the
 
 Current converter behavior notes:
 
-- `metadata` is accepted by validation but ignored for Bedrock Converse requests.
+- Client-supplied `metadata` is accepted by validation but not forwarded directly to Bedrock.
+- The gateway injects Bedrock `requestMetadata` with `request_id`, `user_id`, and `team_id` (when a team is resolved) for invocation-log filtering.
 
 Non-streaming response:
 

--- a/ai-coding-assistants/claude-code-proxy-on-aws/docs/RUNTIME_TRANSLATION.md
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/docs/RUNTIME_TRANSLATION.md
@@ -495,7 +495,11 @@ Important consequence:
   - May be dropped entirely when prior tool-use history is incompatible.
 - `metadata`
   - Accepted by validation.
-  - Not forwarded to Bedrock `requestMetadata`.
+  - Not forwarded directly to Bedrock `requestMetadata`.
+- Server-side request metadata
+  - Runtime injects Bedrock `requestMetadata.request_id = context.request_id`.
+  - Runtime injects Bedrock `requestMetadata.user_id = str(context.user.id)` when user resolution succeeds.
+  - Runtime injects Bedrock `requestMetadata.team_id = str(context.team.id)` when a team is resolved.
 
 ### Message and system content blocks
 
@@ -1033,7 +1037,7 @@ What is not currently implemented:
 
 ## Current Known Gaps
 
-- Request `metadata` is accepted but ignored instead of being forwarded into Bedrock `requestMetadata`.
+- Client-supplied request `metadata` is accepted but still ignored instead of being forwarded into Bedrock `requestMetadata`.
 - Official Anthropic `tool_result.is_error` is not translated into Bedrock `toolResult.status`.
 - Official Anthropic `tool_choice.none` has no explicit runtime handling.
 - Anthropic tool names can be longer than Bedrock's 64-character limit, and the runtime does not pre-validate to the Bedrock limit.

--- a/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/services.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/gateway/domains/runtime/services.py
@@ -104,6 +104,20 @@ class GatewayService:
             self._serialize_payload(payload),
         )
 
+    @staticmethod
+    def _inject_bedrock_request_metadata(
+        request: dict[str, object], context: PolicyContext
+    ) -> dict[str, object]:
+        existing = request.get("requestMetadata")
+        request_metadata = dict(existing) if isinstance(existing, dict) else {}
+        request_metadata["request_id"] = context.request_id
+        if context.user is not None and getattr(context.user, "id", None) is not None:
+            request_metadata["user_id"] = str(context.user.id)
+        if context.team is not None and getattr(context.team, "id", None) is not None:
+            request_metadata["team_id"] = str(context.team.id)
+        request["requestMetadata"] = request_metadata
+        return request
+
     async def process_message(
         self,
         request: MessageRequest,
@@ -123,6 +137,7 @@ class GatewayService:
                 context.cache_policy,
                 context.max_tokens_override,
             )
+            bedrock_request = self._inject_bedrock_request_metadata(bedrock_request, context)
             self._log_bedrock_request_payload(request_id, bedrock_request)
             response = await self._bedrock_client.converse(bedrock_request, context.resolved_model)
             self._log_bedrock_response_payload(request_id, response)
@@ -175,6 +190,7 @@ class GatewayService:
                 context.cache_policy,
                 context.max_tokens_override,
             )
+            bedrock_request = self._inject_bedrock_request_metadata(bedrock_request, context)
             self._log_bedrock_request_payload(request_id, bedrock_request)
             bedrock_stream = await self._bedrock_client.converse_stream(
                 bedrock_request,

--- a/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_runtime_logging.py
+++ b/ai-coding-assistants/claude-code-proxy-on-aws/tests/unit/gateway/test_runtime_logging.py
@@ -218,11 +218,111 @@ async def test_gateway_service_returns_resolved_bedrock_model_id_to_response_con
 
 
 @pytest.mark.asyncio
+async def test_gateway_service_injects_request_metadata_for_bedrock_converse() -> None:
+    policy_chain = SimpleNamespace(evaluate=AsyncMock())
+
+    async def evaluate(context):
+        context.user = SimpleNamespace(id="user-123")
+        context.team = SimpleNamespace(id="team-456")
+        context.virtual_key = SimpleNamespace(id="vk-123")
+        context.resolved_model = SimpleNamespace(
+            id="model-id",
+            bedrock_model_id="zai.glm-5",
+        )
+
+    policy_chain.evaluate.side_effect = evaluate
+    response_converter = SimpleNamespace(
+        convert_response=Mock(return_value=SimpleNamespace()),
+        extract_usage=Mock(return_value=UsageInfo()),
+    )
+    usage_service = SimpleNamespace(
+        record_success=AsyncMock(),
+        record_blocked_request=AsyncMock(),
+        record_error=AsyncMock(),
+    )
+    bedrock_client = SimpleNamespace(
+        converse=AsyncMock(return_value={"output": {"message": {"content": []}}})
+    )
+    service = GatewayService(
+        policy_chain=policy_chain,
+        request_converter=SimpleNamespace(
+            convert_request=Mock(return_value={"modelId": "zai.glm-5"})
+        ),
+        response_converter=response_converter,
+        bedrock_client=bedrock_client,
+        stream_processor=SimpleNamespace(stream_response=Mock()),
+        usage_service=usage_service,
+        session=SimpleNamespace(commit=AsyncMock()),
+        model_catalog_repo=SimpleNamespace(),
+        metrics=_stub_metrics(),
+    )
+
+    await service.process_message(_build_request(), "sk-test", "req-metadata")
+
+    assert bedrock_client.converse.call_args.args[0]["requestMetadata"] == {
+        "request_id": "req-metadata",
+        "user_id": "user-123",
+        "team_id": "team-456",
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_service_injects_request_metadata_for_bedrock_stream() -> None:
+    policy_chain = SimpleNamespace(evaluate=AsyncMock())
+
+    async def evaluate(context):
+        context.user = SimpleNamespace(id="user-123")
+        context.team = SimpleNamespace(id="team-456")
+        context.virtual_key = SimpleNamespace(id="vk-123")
+        context.resolved_model = SimpleNamespace(
+            id="model-id",
+            bedrock_model_id="zai.glm-5",
+        )
+
+    policy_chain.evaluate.side_effect = evaluate
+    usage_service = SimpleNamespace(
+        record_success=AsyncMock(),
+        record_blocked_request=AsyncMock(),
+        record_error=AsyncMock(),
+    )
+    bedrock_client = SimpleNamespace(
+        converse_stream=AsyncMock(return_value={"stream": []}),
+    )
+    stream_processor = SimpleNamespace(stream_response=Mock(return_value=iter(())))
+    service = GatewayService(
+        policy_chain=policy_chain,
+        request_converter=SimpleNamespace(
+            convert_request=Mock(return_value={"modelId": "zai.glm-5"})
+        ),
+        response_converter=SimpleNamespace(
+            convert_response=Mock(),
+            extract_usage=Mock(return_value=UsageInfo()),
+        ),
+        bedrock_client=bedrock_client,
+        stream_processor=stream_processor,
+        usage_service=usage_service,
+        session=SimpleNamespace(commit=AsyncMock()),
+        model_catalog_repo=SimpleNamespace(),
+        metrics=_stub_metrics(),
+    )
+
+    request = _build_request().model_copy(update={"stream": True})
+    await service.process_message_stream(request, "sk-test", "req-stream-metadata")
+
+    assert bedrock_client.converse_stream.call_args.args[0]["requestMetadata"] == {
+        "request_id": "req-stream-metadata",
+        "user_id": "user-123",
+        "team_id": "team-456",
+    }
+
+
+@pytest.mark.asyncio
 async def test_gateway_service_logs_full_payloads_when_enabled(caplog) -> None:
     policy_chain = SimpleNamespace(evaluate=AsyncMock())
 
     async def evaluate(context):
         context.user = SimpleNamespace(id="user-123")
+        context.team = SimpleNamespace(id="team-456")
         context.virtual_key = SimpleNamespace(id="vk-123")
         context.resolved_model = SimpleNamespace(
             id="model-id",
@@ -263,6 +363,7 @@ async def test_gateway_service_logs_full_payloads_when_enabled(caplog) -> None:
     assert '"model":"claude-sonnet-4-6"' in caplog.text
     assert "runtime bedrock request payload request_id=req-payloads" in caplog.text
     assert '"modelId":"zai.glm-5"' in caplog.text
+    assert '"requestMetadata":{"request_id":"req-payloads","user_id":"user-123","team_id":"team-456"}' in caplog.text
     assert "runtime bedrock response payload request_id=req-payloads" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- inject Bedrock `requestMetadata` at the gateway service layer for both `converse` and `converse_stream`
- include `request_id`, `user_id`, and `team_id` when the runtime context has those values
- update runtime docs and add unit coverage for request metadata injection and payload logging

## Why
The gateway already resolves request, user, and team context before invoking Bedrock, but it was not forwarding any of that context into Bedrock invocation metadata. This change makes Bedrock invocation logs filterable by those identifiers without changing the public Anthropic-compatible request shape.

## Impact
- Bedrock requests now include server-generated `requestMetadata`
- client-supplied `metadata` remains accepted but is not forwarded directly
- sync and streaming runtime paths are covered by tests

## Validation
- `pytest tests/unit/gateway/test_runtime_logging.py -q`
- `pytest tests/unit/gateway/test_request_converter.py -q`
- `pytest tests/unit/gateway -q`
