### PR TITLE
Add NemoClaw on AWS with Bedrock sample

### DIFF
--- a/agentic-workloads/nemoclaw-on-aws/.gitignore
+++ b/agentic-workloads/nemoclaw-on-aws/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+.terraform.lock.hcl

--- a/agentic-workloads/nemoclaw-on-aws/README.ja.md
+++ b/agentic-workloads/nemoclaw-on-aws/README.ja.md
@@ -1,0 +1,97 @@
+# NemoClaw on AWS with Bedrock
+
+[NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw)をAWS EC2上にデプロイし、[Amazon Bedrock](https://aws.amazon.com/bedrock/)経由でClaude等のLLMを推論バックエンドとして利用するためのTerraformモジュール。
+
+[LiteLLM](https://docs.litellm.ai/)をOpenAI互換プロキシとして挟むことで、BedrockのAPIをNemoClawから利用可能にしている。
+
+## アーキテクチャ
+
+```
+OpenClaw TUI (sandbox)
+  → https://inference.local/v1 (OpenShell Gateway)
+    → http://172.17.0.1:4000/v1 (LiteLLM proxy on host)
+      → Bedrock API (ap-northeast-1)
+```
+
+## 前提条件
+
+- Terraform >= 1.5
+- AWS CLIが認証済み
+- [Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)がインストール済み（SSM接続に必要）
+- 使用するBedrockモデルへのアクセスが有効化済み
+
+## デプロイ
+
+```bash
+terraform init
+terraform apply
+```
+
+apply完了後、User Data（Docker + LiteLLM + NemoClawインストール）の完了まで3〜5分待つ。
+
+## セットアップ
+
+### 1. SSMで接続
+
+```bash
+# terraform outputに接続コマンドが表示される
+aws ssm start-session --region ap-northeast-1 --target <instance-id>
+```
+
+### 2. NemoClawのonboardを実行
+
+```bash
+sudo su - ec2-user
+nemoclaw onboard
+```
+
+onboardの対話型ウィザードで以下を選択:
+
+| ステップ | 選択肢 |
+|---|---|
+| Inference options | `3) Other OpenAI-compatible endpoint` |
+| Base URL | `http://172.17.0.1:4000/v1` |
+| API key | `dummy`（LiteLLMにmaster_keyを設定していないため） |
+| Model | `claude-opus`（`variables.tf`の`litellm_model_name`に対応） |
+
+### 3. 動作確認
+
+onboard完了後:
+
+```bash
+nemoclaw my-assistant connect
+openclaw tui
+```
+
+TUIが起動し、ステータスバーに `inference/claude-opus` と表示されれば成功。
+
+## ダッシュボード
+
+SSMポートフォワードでローカルからNemoClawダッシュボードにアクセスできる:
+
+```bash
+# terraform outputに表示されるコマンドを使用
+aws ssm start-session --region ap-northeast-1 --target <instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["18789"],"localPortNumber":["18789"]}'
+```
+
+ブラウザで `http://127.0.0.1:18789` を開く（onboard完了時に表示されるトークン付きURLを使用）。
+
+## 変数
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `instance_type` | `m5.xlarge` | EC2インスタンスタイプ（4 vCPU / 16GB RAM） |
+| `volume_size` | `40` | ルートEBSボリュームサイズ（GB） |
+| `bedrock_model_id` | `global.anthropic.claude-opus-4-6-v1` | BedrockモデルID（[推論プロファイル](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html)推奨） |
+| `bedrock_region` | `ap-northeast-1` | Bedrock APIのリージョン |
+| `litellm_model_name` | `claude-opus` | NemoClawのonboardで指定するモデルエイリアス |
+| `name_prefix` | `nemoclaw` | リソース名のプレフィックス |
+
+## クリーンアップ
+
+```bash
+terraform destroy
+```
+

--- a/agentic-workloads/nemoclaw-on-aws/README.md
+++ b/agentic-workloads/nemoclaw-on-aws/README.md
@@ -1,0 +1,106 @@
+# NemoClaw on AWS with Bedrock
+
+[日本語版 / Japanese](README.ja.md)
+
+Terraform module to deploy [NVIDIA NemoClaw](https://github.com/NVIDIA/NemoClaw) on an AWS EC2 instance, using [Amazon Bedrock](https://aws.amazon.com/bedrock/) as the LLM inference backend via a [LiteLLM](https://docs.litellm.ai/) proxy.
+
+## Architecture
+
+```
+OpenClaw TUI (sandbox)
+  → https://inference.local/v1 (OpenShell Gateway)
+    → http://172.17.0.1:4000/v1 (LiteLLM proxy on host)
+      → Bedrock API (ap-northeast-1)
+```
+
+NemoClaw does not natively support Bedrock, so LiteLLM acts as an OpenAI-compatible proxy that translates requests to the Bedrock API.
+
+## Prerequisites
+
+- Terraform >= 1.5
+- AWS CLI configured with valid credentials
+- [Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed (required for SSM connection)
+- Bedrock model access enabled for the target model
+
+## Deploy
+
+```bash
+terraform init
+terraform apply
+```
+
+Wait 3–5 minutes after apply for User Data (Docker + LiteLLM + NemoClaw installation) to complete.
+
+## Setup
+
+### 1. Connect via SSM
+
+```bash
+# The connection command is shown in terraform output
+aws ssm start-session --region ap-northeast-1 --target <instance-id>
+```
+
+### 2. Run NemoClaw onboard
+
+```bash
+sudo su - ec2-user
+nemoclaw onboard
+```
+
+Select the following in the interactive wizard:
+
+| Step | Selection |
+|---|---|
+| Inference options | `3) Other OpenAI-compatible endpoint` |
+| Base URL | `http://172.17.0.1:4000/v1` |
+| API key | `dummy` (no master_key configured on LiteLLM) |
+| Model | `claude-opus` (matches `litellm_model_name` in `variables.tf`) |
+
+### 3. Verify
+
+After onboard completes:
+
+```bash
+nemoclaw my-assistant connect
+openclaw tui
+```
+
+If the status bar shows `inference/claude-opus`, the setup is working.
+
+## Dashboard
+
+Access the NemoClaw dashboard locally via SSM port forwarding:
+
+```bash
+# Use the command shown in terraform output
+aws ssm start-session --region ap-northeast-1 --target <instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["18789"],"localPortNumber":["18789"]}'
+```
+
+Open `http://127.0.0.1:18789` in your browser (use the token URL displayed after onboard).
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `instance_type` | `m5.xlarge` | EC2 instance type (4 vCPU / 16 GB RAM) |
+| `volume_size` | `40` | Root EBS volume size (GB) |
+| `bedrock_model_id` | `global.anthropic.claude-opus-4-6-v1` | Bedrock model ID ([inference profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html) recommended) |
+| `bedrock_region` | `ap-northeast-1` | AWS region for Bedrock API |
+| `litellm_model_name` | `claude-opus` | Model alias used in NemoClaw onboard |
+| `name_prefix` | `nemoclaw` | Prefix for resource names |
+
+## Cleanup
+
+```bash
+terraform destroy
+```
+
+## Security
+
+See [CONTRIBUTING](../../CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License. See the [LICENSE](../../LICENSE) file.

--- a/agentic-workloads/nemoclaw-on-aws/main.tf
+++ b/agentic-workloads/nemoclaw-on-aws/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.bedrock_region
+}
+
+data "aws_ssm_parameter" "ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+# --- IAM ---
+
+resource "aws_iam_role" "this" {
+  name = "${var.name_prefix}-ec2-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "bedrock" {
+  name = "${var.name_prefix}-bedrock"
+  role = aws_iam_role.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${var.name_prefix}-ec2-profile"
+  role = aws_iam_role.this.name
+}
+
+# --- Security Group ---
+
+resource "aws_security_group" "this" {
+  name_prefix = "${var.name_prefix}-"
+  description = "NemoClaw EC2 - egress only"
+  vpc_id      = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name_prefix}-sg" }
+}
+
+# --- EC2 ---
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ssm_parameter.ami.value
+  instance_type          = var.instance_type
+  iam_instance_profile   = aws_iam_instance_profile.this.name
+  vpc_security_group_ids = [aws_security_group.this.id]
+
+  root_block_device {
+    volume_size = var.volume_size
+    volume_type = "gp3"
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh", {
+    litellm_model_name = var.litellm_model_name
+    bedrock_model_id   = var.bedrock_model_id
+    bedrock_region     = var.bedrock_region
+  })
+
+  tags = { Name = "${var.name_prefix}-server" }
+}

--- a/agentic-workloads/nemoclaw-on-aws/outputs.tf
+++ b/agentic-workloads/nemoclaw-on-aws/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.this.id
+}
+
+output "ssm_connect" {
+  description = "SSM session command"
+  value       = "aws ssm start-session --region ${var.bedrock_region} --target ${aws_instance.this.id}"
+}
+
+output "ssm_port_forward" {
+  description = "SSM port forward command for NemoClaw dashboard"
+  value       = "aws ssm start-session --region ${var.bedrock_region} --target ${aws_instance.this.id} --document-name AWS-StartPortForwardingSession --parameters '{\"portNumber\":[\"18789\"],\"localPortNumber\":[\"18789\"]}'"
+}

--- a/agentic-workloads/nemoclaw-on-aws/user_data.sh
+++ b/agentic-workloads/nemoclaw-on-aws/user_data.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euxo pipefail
+
+# System packages
+yum install -y docker git python3-pip perl-Digest-SHA
+systemctl enable --now docker
+usermod -aG docker ec2-user
+
+# LiteLLM config
+mkdir -p /opt/litellm/config
+cat > /opt/litellm/config/config.yaml << 'LITELLM'
+model_list:
+  - model_name: "${litellm_model_name}"
+    litellm_params:
+      model: "bedrock/${bedrock_model_id}"
+      aws_region_name: "${bedrock_region}"
+LITELLM
+
+# LiteLLM
+sudo -u ec2-user pip3 install --user 'litellm[proxy]'
+
+# LiteLLM systemd service
+cat > /etc/systemd/system/litellm.service << 'SVC'
+[Unit]
+Description=LiteLLM Proxy
+After=network.target docker.service
+
+[Service]
+User=ec2-user
+Environment=PATH=/home/ec2-user/.local/bin:/usr/local/bin:/usr/bin
+ExecStart=/home/ec2-user/.local/bin/litellm --config /opt/litellm/config/config.yaml --host 0.0.0.0 --port 4000
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SVC
+
+systemctl daemon-reload
+systemctl enable --now litellm
+
+# NemoClaw (install only, onboard is manual)
+sudo -u ec2-user bash -c 'curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash -s -- --non-interactive --yes-i-accept-third-party-software' || true

--- a/agentic-workloads/nemoclaw-on-aws/variables.tf
+++ b/agentic-workloads/nemoclaw-on-aws/variables.tf
@@ -1,0 +1,35 @@
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "m5.xlarge"
+}
+
+variable "volume_size" {
+  description = "Root EBS volume size in GB"
+  type        = number
+  default     = 40
+}
+
+variable "bedrock_model_id" {
+  description = "Bedrock model ID for LiteLLM config (inference profile recommended)"
+  type        = string
+  default     = "global.anthropic.claude-opus-4-6-v1"
+}
+
+variable "bedrock_region" {
+  description = "AWS region for Bedrock API calls"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "litellm_model_name" {
+  description = "Model alias used by NemoClaw (referenced in onboard)"
+  type        = string
+  default     = "claude-opus"
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "nemoclaw"
+}


### PR DESCRIPTION
Terraform module to deploy NVIDIA NemoClaw on EC2 with Amazon Bedrock as the LLM backend via LiteLLM proxy.

## What's included
- `main.tf` — EC2 instance with IAM role (SSM + Bedrock), security group (egress-only)
- `user_data.sh` — Automated setup of Docker, LiteLLM proxy, and NemoClaw
- `variables.tf` / `outputs.tf` — Configurable model, region, instance type
- `README.md` (English) + `README.ja.md` (Japanese)

## Architecture
NemoClaw does not natively support Bedrock, so LiteLLM acts as an OpenAI-compatible proxy bridging NemoClaw to the Bedrock API.

## Testing
Deployed and verified on `m5.xlarge` with Claude Opus 4.6 via cross-region inference profile in ap-northeast-1.