### PR TITLE
fix(finetuning-on-eks): add missing resources in ray kustomization

### DIFF
--- a/ai-infra/finetuning-on-eks/kubernetes/base/ray/kustomization.yaml
+++ b/ai-infra/finetuning-on-eks/kubernetes/base/ray/kustomization.yaml
@@ -9,6 +9,8 @@ configurations:
 resources:
   - s3-config.yaml
   - rayjob.yaml
+  - serviceaccount.yaml
+  - efs-pvc.yaml
 
 commonLabels:
   app.kubernetes.io/part-of: fine-tuning-on-eks


### PR DESCRIPTION
Two lines of code which adds missing resources to ray kustomization in `finetuning-on-eks` example.
Without this, Ray pod creation fails. 

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
