### PR TITLE
feat(security): Add bulk CloudHSM to KMS asymmetric key migration scripts

### DIFF
--- a/security/cloudhsm-to-kms-keys-migration/.gitattributes
+++ b/security/cloudhsm-to-kms-keys-migration/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/security/cloudhsm-to-kms-keys-migration/.gitignore
+++ b/security/cloudhsm-to-kms-keys-migration/.gitignore
@@ -1,0 +1,3 @@
+CLAUDE.md
+cert/
+

--- a/security/cloudhsm-to-kms-keys-migration/README.md
+++ b/security/cloudhsm-to-kms-keys-migration/README.md
@@ -1,0 +1,470 @@
+# CloudHSM to KMS Keys Migration
+
+The AWS blog post ["How to migrate asymmetric keys from CloudHSM to AWS KMS"](https://aws.amazon.com/blogs/security/how-to-migrate-asymmetric-keys-from-cloudhsm-to-aws-kms/) provides detailed, step-by-step guidance on how to securely migrate asymmetric key (such as an RSA or ECC private key) from AWS CloudHSM to AWS Key Management Service (KMS). While it provides a step-by-step method for migrating a single asymmetric key from CloudHSM to AWS KMS, it doesn't offer a systematic process for bulk migration of many keys.
+
+This project provides a set of scripts to facilitate the bulk migration of asymmetric cryptographic keys (RSA and ECC keys) from AWS CloudHSM to AWS Key Management Service (KMS). The project includes separate migration scripts for EC and RSA keys, with comprehensive logging and result tracking.
+
+## Key Features
+
+### Test Key Generation
+
+- `generate-cloudhsm-test-keys.sh`: Creates test ECC key pairs in CloudHSM for testing the migration process
+
+### Key Discovery and Listing
+
+- `list-cloudhsm-keys.sh`: **Unified script** for listing both private and public keys with pattern filtering
+  - Usage: `./list-cloudhsm-keys.sh [KEY_CLASS] [OUTPUT_FILE] [PATTERN]`
+  - Supports `private-key` or `public-key` classes with customizable output files and regex patterns
+- `list-cloudhsm-private-keys.sh`: **Wrapper script** for backward compatibility (calls unified script)
+  - Usage: `./list-cloudhsm-private-keys.sh [PATTERN] [OUTPUT_FILE]`
+- `list-cloudhsm-public-keys.sh`: **Wrapper script** for backward compatibility (calls unified script)
+  - Usage: `./list-cloudhsm-public-keys.sh [PATTERN] [OUTPUT_FILE]`
+- `count-cloudhsm-keys-by-regex.sh`: Counts keys matching a specific pattern with statistics by type and class
+  - Usage: `./count-cloudhsm-keys-by-regex.sh [PATTERN]`
+
+### Batch Processing Tools
+
+- `count-key-types-from-json.py`: Analyzes key types and counts in JSON files for migration planning
+  - Usage: `python3 count-key-types-from-json.py private_keys.json`
+  - Provides summary statistics by key type (EC, RSA, etc.)
+- `split-keys-in-json.py`: Splits large key JSON files into manageable batches for safer migration
+  - Usage: Run script to split `private_keys.json` into batches of 50 keys per file in `split_keys_output/` directory
+  - Organizes keys by type (EC, RSA) and creates numbered batch files
+  - Reduces risk of migration failures and enables parallel processing
+
+### Bulk Key Migration
+
+**Separate migration scripts for different key types:**
+
+- `migrate-cloudhsm-ec-keys-to-kms.sh`: Migrates **EC (Elliptic Curve) keys**
+
+  - Supports secp256k1 (ECC_SECG_P256K1) and prime256v1/secp256r1 (ECC_NIST_P256) curves
+  - Uses `ec-point` attribute for key pair matching
+  - Uses ECDSA_SHA_256 signing algorithm for verification
+
+- `migrate-cloudhsm-rsa-keys-to-kms.sh`: Migrates **RSA keys**
+  - Supports RSA-2048, RSA-3072, and RSA-4096 key sizes
+  - Uses `modulus` attribute for key pair matching
+  - Uses RSASSA_PKCS1_V1_5_SHA_256 signing algorithm for verification
+
+**Common migration workflow:**
+
+- Reads private key information from JSON files
+- Creates appropriate KMS keys based on key type and specifications
+- Obtains wrapping parameters from AWS KMS
+- Imports the KMS wrapping key into CloudHSM
+- Wraps the private key inside CloudHSM using the imported wrapping key
+- Imports the wrapped key material into AWS KMS
+- Validates the migration by performing a sign/verify test operation
+- Tracks successful and failed migrations in timestamped result files
+
+### Advanced Features
+
+- **Organized file management**: All intermediate files stored in `staging/` directory
+- **Comprehensive logging**: Detailed logs with timestamps for debugging and audit
+- **Clean console output**: Only key status shown on console, details in log files
+- **Graceful error handling**: Continues processing if individual keys fail
+- **Public key fallback**: Skips keys without corresponding public keys
+- **Result tracking**: CSV format results with timestamps
+
+### Key Cleanup
+
+- `delete-cloudhsm-keys-by-regex.sh`: Efficiently deletes keys from CloudHSM matching a specific pattern
+  - Uses key-reference for direct deletion (faster than label-based lookups)
+  - Usage: `./delete-cloudhsm-keys-by-regex.sh [PATTERN]`
+  - Supports regex patterns with safe default behavior
+
+## Pre-requisites
+
+This guide only works on Windows or Linux since CloudHSM-CLI is not available in Mac.
+
+This project assumes that the CloudHSM cluster has been setup and activated. Crypto-user has been created. CloudHSM-CLI is installed.
+
+**New to CloudHSM?** See our [Quick Setup Guide for CloudHSM](docs/Quick%20Setup%20Guide%20for%20CloudHSM.md) which provides step-by-step instructions for setting up a CloudHSM cluster from scratch, including VPC configuration, cluster creation, HSM initialization, and crypto-user setup.
+
+1. Add CloudHSM bin folder to PATH so that we can use `cloudhsm-cli` instead of `/opt/cloudhsm/bin/cloudhsm-cli`.
+
+```
+export PATH=$PATH:/opt/cloudhsm/bin
+```
+
+2. Set CloudHSM User in environment variables. Replace username and password accordingly. This is so that you can call `cloudhsm-cli` directly in terminal.
+
+```
+export CLOUDHSM_ROLE=crypto-user
+export CLOUDHSM_PIN="user2:Mylife123"
+```
+
+## Usage Steps
+
+### 1. Generate Test Keys (Optional)
+
+Generate test ECC key pairs in CloudHSM for testing the migration process:
+
+```bash
+./generate-cloudhsm-test-keys.sh
+```
+
+### 2. Discover and List Keys
+
+**Option A: Using the unified script (recommended):**
+
+```bash
+# List all private keys with default output
+./list-cloudhsm-keys.sh
+
+# List all public keys to default file
+./list-cloudhsm-keys.sh public-key
+
+# List keys with custom output file and pattern
+./list-cloudhsm-keys.sh private-key "my_private_keys.json" "^test-*"
+./list-cloudhsm-keys.sh public-key "my_public_keys.json" "^prod-*"
+```
+
+**Option B: Using individual scripts (backward compatibility):**
+
+```bash
+# List with default settings
+./list-cloudhsm-private-keys.sh
+./list-cloudhsm-public-keys.sh
+
+# List with custom patterns and output files
+./list-cloudhsm-private-keys.sh "^test-*" "test_private_keys.json"
+./list-cloudhsm-public-keys.sh "^prod-*" "prod_public_keys.json"
+```
+
+**Count keys by pattern:**
+
+```bash
+# Count all keys
+./count-cloudhsm-keys-by-regex.sh
+
+# Count keys matching specific patterns
+./count-cloudhsm-keys-by-regex.sh "^test-*"
+./count-cloudhsm-keys-by-regex.sh ".*-backup$"
+```
+
+This creates:
+
+- `private_keys.json`: Contains all private keys with metadata (default)
+- `public_keys.json`: Contains all public keys with metadata (default)
+- Or custom JSON files based on your specified output filenames
+
+**Key matching logic:**
+
+- **EC keys**: Private and public keys are matched using the `ec-point` attribute
+- **RSA keys**: Private and public keys are matched using the `modulus` attribute
+- Each key is uniquely identified by its `key-reference` value
+
+### 3. Analyze and Prepare for Batch Migration (Recommended for Large Datasets)
+
+**⚠️ Important**: For large numbers of keys, batch processing is strongly recommended to reduce risk and enable better progress tracking.
+
+**Step 3a: Analyze Key Distribution**
+
+```bash
+# Get an overview of key types and counts
+python3 count-key-types-from-json.py private_keys.json
+```
+
+Example output:
+
+```
+Key Type Counts:
+--------------------
+ec: 150
+rsa: 75
+--------------------
+Total: 225
+```
+
+**Step 3b: Split Keys into Manageable Batches**
+
+```bash
+# Split keys into batches of 50 keys per file
+python3 split-keys-in-json.py
+```
+
+This creates a `split_keys_output/` directory with organized batch files:
+
+```
+split_keys_output/
+├── ec_keys_part_001.json      # EC keys batch 1 (50 keys)
+├── ec_keys_part_002.json      # EC keys batch 2 (50 keys)
+├── ec_keys_part_003.json      # EC keys batch 3 (50 keys)
+├── rsa_keys_part_001.json     # RSA keys batch 1 (50 keys)
+└── rsa_keys_part_002.json     # RSA keys batch 2 (25 keys)
+```
+
+**Benefits of batch processing:**
+
+- **Reduced risk**: If migration fails, only one batch is affected
+- **Progress tracking**: Clear visibility of completed vs remaining batches
+- **Parallel processing**: Can run multiple batches simultaneously if needed
+- **Resource management**: Prevents overwhelming CloudHSM or KMS with large operations
+
+### 4. Run Key Migration
+
+```bash
+# Migrate EC key batches one by one
+./migrate-cloudhsm-ec-keys-to-kms.sh split_keys_output/ec_keys_part_001.json
+./migrate-cloudhsm-ec-keys-to-kms.sh split_keys_output/ec_keys_part_002.json
+
+# Migrate RSA key batches one by one
+./migrate-cloudhsm-rsa-keys-to-kms.sh split_keys_output/rsa_keys_part_001.json
+./migrate-cloudhsm-rsa-keys-to-kms.sh split_keys_output/rsa_keys_part_002.json
+```
+
+**Batch Migration Best Practices:**
+
+- Process one batch at a time to monitor progress and handle any issues
+- Check result files after each batch to ensure successful migration
+- Keep track of completed batches to avoid reprocessing
+- Monitor CloudHSM and KMS service limits and throttling
+
+**Console output example:**
+
+```
+CloudHSM Key: ec-priv-16, 0x000000000004392a ---------
+  KMS Key: arn:aws:kms:region:account:key/59a01311-ea72-4f91-bd90-cb7f6511aec0
+
+CloudHSM Key: rsa-priv-4, 0x0000000000000128 ---------
+  KMS Key: arn:aws:kms:region:account:key/1685b41b-9b99-4ce0-b4e1-6945c4feb160
+```
+
+### 5. Review Results
+
+Migration results are saved with timestamps for each batch:
+
+```bash
+# Each batch creates its own result files
+cat result_success_ec_keys_part_001_YYYYMMDD_HHMM.txt
+cat result_success_ec_keys_part_002_YYYYMMDD_HHMM.txt
+cat result_failed_ec_keys_part_001_YYYYMMDD_HHMM.txt
+
+# Combine all successful migrations across batches
+cat result_success_*_YYYYMMDD_HHMM.txt > all_successful_migrations.txt
+
+# Count total successes and failures
+wc -l result_success_*.txt
+wc -l result_failed_*.txt
+```
+
+**Migration completion summary:**
+Each migration script now shows completion statistics:
+
+```
+------ Migration Complete: 45 successful, 5 failed --------
+```
+
+### 5. Clean Up Test Keys (Optional)
+
+Remove test keys from CloudHSM after testing:
+
+```bash
+# Delete all keys (use with caution!)
+./delete-cloudhsm-keys-by-regex.sh
+
+# Delete keys matching specific patterns
+./delete-cloudhsm-keys-by-regex.sh "^test-*"       # Keys starting with "test-"
+./delete-cloudhsm-keys-by-regex.sh ".*-backup$"    # Keys ending with "-backup"
+./delete-cloudhsm-keys-by-regex.sh "^mvgx-*"       # Keys starting with "mvgx-"
+
+# Delete keys for specific testing scenarios
+./delete-cloudhsm-keys-by-regex.sh "^ec-test-*"    # EC test keys
+./delete-cloudhsm-keys-by-regex.sh "^rsa-test-*"   # RSA test keys
+```
+
+**⚠️ Warning**: Be very careful with deletion patterns. Always test your regex pattern with the count script first:
+
+```bash
+# Preview what will be deleted
+./count-cloudhsm-keys-by-regex.sh "^test-*"
+# Then delete if the count looks correct
+./delete-cloudhsm-keys-by-regex.sh "^test-*"
+```
+
+## File Organization
+
+After running the migration scripts, your directory will contain:
+
+```
+├── staging/                           # Intermediate files for each key
+│   ├── 0x123_WrappingPublicKey.*
+│   ├── 0x123_ImportToken.*
+│   ├── 0x123_EncryptedKeyMaterial.bin
+│   └── 0x123_public_key.pem
+├── split_keys_output/                 # Batch processing output (if used)
+│   ├── ec_keys_part_001.json         # EC keys batch 1
+│   ├── ec_keys_part_002.json         # EC keys batch 2
+│   ├── rsa_keys_part_001.json        # RSA keys batch 1
+│   └── rsa_keys_part_002.json        # RSA keys batch 2
+├── private_keys.json                  # All private keys from CloudHSM
+├── public_keys.json                   # All public keys from CloudHSM
+├── result_success_*_YYYYMMDD_HHMM.txt # Successful migrations (CSV)
+├── result_failed_*_YYYYMMDD_HHMM.txt  # Failed migrations (CSV)
+├── log_YYYYMMDD_HHMM.log             # Detailed execution logs
+├── count-key-types-from-json.py       # Key analysis utility
+└── split-keys-in-json.py              # Batch splitting utility
+```
+
+**For batch migrations, results are organized by batch:**
+
+- Each batch creates separate result and log files with timestamps
+- File naming includes the source JSON filename for easy tracking
+- Use `cat result_success_*.txt` to combine results across all batches
+
+## Inside Migration Script
+
+### Step 1: Create a KMS key without key material in AWS KMS
+
+This is a new KMS key which will be migrated from a CloudHSM Key. The key material will be provided by the existing key in CloudHSM.
+
+```
+export KMS_KEY_ID=$(aws kms create-key --origin EXTERNAL --key-spec ECC_NIST_P256 --key-usage SIGN_VERIFY --query 'KeyMetadata.KeyId' --output text)
+
+echo $KMS_KEY_ID
+```
+
+### Step 2: Download the wrapping public key and import token from AWS KMS
+
+We can download a wrapping key for above KMS key. The wrapping key will be imported into CloudHSM to encrypt the target key in CloudHMS before it is exported.
+
+```
+aws kms get-parameters-for-import \
+  --key-id "$KMS_KEY_ID" \
+  --wrapping-algorithm RSAES_OAEP_SHA_256 \
+  --wrapping-key-spec RSA_4096 \
+  --query "[ImportToken, PublicKey]" \
+  --output text \
+  | awk '{print $1 > "ImportToken.b64"; print $2 > "WrappingPublicKey.b64"}'
+
+```
+
+Decode the base64 encoding
+
+```
+openssl enc -d -base64 -A -in WrappingPublicKey.b64 -out WrappingPublicKey.bin
+
+ls -la WrappingPublicKey*
+```
+
+Convert the wrapping public key from DER to PEM format
+
+```
+openssl rsa -pubin -in WrappingPublicKey.bin -inform DER -outform PEM -out WrappingPublicKey.pem
+
+ls -la WrappingPublicKey*
+```
+
+### Step 3: Import the wrapping key provided by AWS KMS into CloudHSM
+
+You may change the label value. You will need to use the same label value to refer to the wrapping key.
+
+```
+cloudhsm-cli key import pem --path ./WrappingPublicKey.pem --label kms-wrapping-key --key-type-class rsa-public --attributes wrap=true
+```
+
+### Step 4: Wrap the private key inside CloudHSM with the imported wrapping public key from AWS KMS
+
+Save the wrapped key.
+
+```
+cloudhsm-cli key wrap rsa-oaep \
+    --payload-filter "key-reference=$KEY_REF" \
+    --wrapping-filter "key-reference=$WRAP_KEY_REF" \
+    --hash-function sha256 --mgf mgf1-sha256 \
+    --path $WRAPPED_KEY_FILE
+```
+
+### Step 5: Import the wrapped key material to AWS KMS
+
+Once the key is wrapped, import it to AWS KMS using the import token:
+
+```
+aws kms import-key-material \
+    --key-id $KMS_KEY_ID \
+    --encrypted-key-material fileb://$WRAPPED_KEY_FILE \
+    --import-token fileb://$IMPORT_TOKEN_BIN \
+    --expiration-model KEY_MATERIAL_DOES_NOT_EXPIRE
+```
+
+### Step 6: Test the migrated key by signing and verifying
+
+To ensure the migration was successful, perform a sign/verify test:
+
+1. First, find the corresponding public key in CloudHSM:
+
+```
+PUBLIC_KEY_REF=$(cat public_keys.json | jq -r --arg EC_POINT "$KEY_EC_POINT" '.data.matched_keys[] | select(.attributes."ec-point" == $EC_POINT) | ."key-reference"')
+```
+
+2. Export the public key to PEM format:
+
+```
+cloudhsm-cli key generate-file --encoding pem --path $PUBLIC_KEY_PEM_FILE --filter "key-reference=$PUBLIC_KEY_REF"
+```
+
+3. Create a test message and sign it with the KMS key:
+
+```
+echo -n 'Testing My Imported Key!' | openssl base64 -out test_msg_base64.txt
+aws kms sign --key-id $KMS_KEY_ID --message fileb://test_msg_base64.txt --message-type RAW --signing-algorithm ECDSA_SHA_256 | jq -r '.Signature' > test_msg_signature.sig
+openssl enc -d -base64 -in test_msg_signature.sig -out test_msg_signature.bin
+```
+
+4. Verify the signature using the public key from CloudHSM:
+
+```
+openssl dgst -sha256 -verify $PUBLIC_KEY_PEM_FILE -signature test_msg_signature.bin test_msg_base64.txt
+```
+
+### Step 7: Record migration results
+
+The script tracks the success or failure of each key migration:
+
+- For successful migrations, the CloudHSM key reference, label, and corresponding KMS key ID are recorded in `result_success_<input_filename>_<timestamp>.txt`
+- For failed migrations, the CloudHSM key reference and label are recorded in `result_failed_<input_filename>_<timestamp>.txt`
+
+This allows for easy tracking of which keys were successfully migrated and which ones may need attention.
+
+### Managing CloudHSM Key Capacity
+
+**⚠️ Important Consideration**: The migration process inserts a new RSA public key (wrapping key) into CloudHSM for each key migration. This will cause the total number of keys in CloudHSM to increase significantly during bulk migrations.
+
+When CloudHSM reaches its key capacity limit, the migration script may fail. CloudHSM has specific [key capacity limits](https://docs.aws.amazon.com/cloudhsm/latest/userguide/ki-all.html#ki-all-7) that vary by HSM type.
+
+**Recommended Solution**: Periodically identify and delete wrapping keys during batch migrations to prevent capacity issues. These wrapping keys are safe to delete after successful key migration since they are only needed during the import process.
+
+**Identifying wrapping keys:**
+All wrapping keys created by the migration scripts use the label prefix `kms_wrapping_key_for_`. You can count and manage them using:
+
+```bash
+# Count existing wrapping keys
+./count-cloudhsm-keys-by-regex.sh kms_wrapping_key_for_.*
+
+# Delete wrapping keys between migration batches
+./delete-cloudhsm-keys-by-regex.sh kms_wrapping_key_for_.*
+```
+
+**Best Practice**: 
+- Monitor wrapping key count during large migrations
+- Delete wrapping keys after completing each batch of migrations
+- Ensure successful migration verification before deleting wrapping keys
+
+### Clean up
+
+After the operation, multiple wrapping keys are imported into CloudHSM as public keys. In the migration script, they are set with the same prefix `kms_wrapping_key_for_*`. You may clean up these wrapping keys from CloudHSM after operation using the commands shown above.
+
+## Disclaimer
+
+This code is developed for personal interest and educational purposes only. It is **NOT intended for production use**.
+
+**Use at your own risk.** The authors and contributors:
+
+- Make no warranties or guarantees about the functionality, security, or reliability of this code
+- Are not responsible for any data loss, security breaches, or other damages that may result from its use
+- Strongly recommend thorough testing in non-production environments before any production consideration
+- Advise consulting with AWS security and cryptography experts before implementing any key migration strategies
+
+Key migration involves sensitive cryptographic operations that can permanently affect your security infrastructure. Always follow AWS best practices and your organization's security policies.

--- a/security/cloudhsm-to-kms-keys-migration/count-cloudhsm-keys-by-regex.sh
+++ b/security/cloudhsm-to-kms-keys-migration/count-cloudhsm-keys-by-regex.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Counts CloudHSM keys matching a regex pattern on their labels.
+# Paginates through all keys in CloudHSM, filters by configurable label pattern,
+# and displays count statistics grouped by key type and class.
+#
+# Usage:
+#   ./count-cloudhsm-keys-by-regex.sh [PATTERN]
+#
+# Arguments:
+#   PATTERN      - Regex pattern to match key labels (default: ".*" matches all)
+#
+# Examples:
+#   ./count-cloudhsm-keys-by-regex.sh                  # Count all keys
+#   ./count-cloudhsm-keys-by-regex.sh "test.*"        # Count keys starting with "test"
+#   ./count-cloudhsm-keys-by-regex.sh ".*-backup$"    # Count keys ending with "-backup"
+
+set -eo pipefail
+export PATH=$PATH:/opt/cloudhsm/bin
+
+# Default pattern to match all labels
+default_pattern=".*"
+# Get label pattern from command line argument, use default if no argument provided
+label_pattern="${1:-$default_pattern}"   
+
+MAX_ITEMS=50
+STARTING_TOKEN=""
+
+echo "Counting keys matching pattern: $label_pattern"
+echo "=========================================="
+
+# Step 1: List all keys matching the label pattern
+echo "Step 1: Collecting all keys matching pattern '$label_pattern'..."
+all_matching_keys=""
+
+while true; do
+  # Build the base command
+  CMD="cloudhsm-cli key list --max-items $MAX_ITEMS --verbose"
+  if [ -n "$STARTING_TOKEN" ]; then
+    CMD="$CMD --starting-token $STARTING_TOKEN"
+  fi
+
+  # Run the command and capture output
+  OUTPUT=$($CMD)
+
+  # Filter keys that match the pattern and append to collection
+  keys_batch=$(echo "$OUTPUT" | jq -c --arg pattern "$label_pattern" '
+    .data.matched_keys[] | select(.attributes.label // "" | test($pattern))
+  ')
+  
+  if [ -n "$keys_batch" ]; then
+    all_matching_keys="$all_matching_keys$keys_batch"$'\n'
+  fi
+
+  # Get the next_token from the output
+  NEXT_TOKEN=$(echo "$OUTPUT" | jq -r '.data.next_token // empty')
+
+  # Stop if there is no next_token
+  if [ -z "$NEXT_TOKEN" ]; then
+    break
+  fi
+
+  STARTING_TOKEN="$NEXT_TOKEN"
+done
+
+# Step 2: Count keys by type and class
+echo "Step 2: Counting keys by type and class..."
+echo
+
+if [ -n "$all_matching_keys" ]; then
+  total_matching=$(echo "$all_matching_keys" | grep -c '^{' || echo "0")
+  echo "Found $total_matching keys matching the pattern"
+  echo
+  
+  echo "Key Type        | Class       | Count"
+  echo "----------------|-------------|-------"
+  
+  # Use jq to extract key-type and class, then count
+  echo "$all_matching_keys" | jq -r '[(.attributes."key-type" // "unknown"), (.attributes.class // "unknown")] | @tsv' | \
+    sort | uniq -c | while read count key_type key_class; do
+      printf "%-15s | %-11s | %d\n" "$key_type" "$key_class" "$count"
+    done
+  
+  echo "----------------|-------------|-------"
+  printf "%-15s | %-11s | %d\n" "TOTAL" "" "$total_matching"
+else
+  echo "No keys found matching pattern '$label_pattern'"
+fi

--- a/security/cloudhsm-to-kms-keys-migration/count-key-types-from-json.py
+++ b/security/cloudhsm-to-kms-keys-migration/count-key-types-from-json.py
@@ -1,0 +1,48 @@
+import json
+from collections import Counter
+
+
+def count_keys_by_type(json_file_path):
+    """
+    Count the number of keys grouped by key-types from a JSON file.
+
+    Args:
+        json_file_path (str): Path to the JSON file
+    """
+
+    # Read the JSON file
+    with open(json_file_path, 'r') as file:
+        data = json.load(file)
+
+    # Extract matched_keys
+    matched_keys = data['data']['matched_keys']
+
+    # Count keys by type
+    key_type_counts = Counter()
+
+    for key_entry in matched_keys:
+        if 'attributes' in key_entry and 'key-type' in key_entry['attributes']:
+            key_type = key_entry['attributes']['key-type']
+            key_type_counts[key_type] += 1
+        else:
+            key_type_counts['unknown'] += 1
+
+    # Print results
+    print(f"Key Type Counts:")
+    print("-" * 20)
+    for key_type, count in sorted(key_type_counts.items()):
+        print(f"{key_type}: {count}")
+    print("-" * 20)
+    print(f"Total: {sum(key_type_counts.values())}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python3 key-type-count.py <json_file_path>")
+        print("Example: python3 key-type-count.py private_keys.json")
+        sys.exit(1)
+
+    json_file_path = sys.argv[1]
+    count_keys_by_type(json_file_path)

--- a/security/cloudhsm-to-kms-keys-migration/delete-cloudhsm-keys-by-regex.sh
+++ b/security/cloudhsm-to-kms-keys-migration/delete-cloudhsm-keys-by-regex.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Deletes CloudHSM keys matching a regex pattern on their labels.
+# Uses key-reference for efficient direct deletion without duplicate lookups.
+#
+# Usage:
+#   ./delete-cloudhsm-keys-by-regex.sh [PATTERN]
+#
+# Arguments:
+#   PATTERN      - Regex pattern to match key labels (default: ".*" matches all)
+#
+# Examples:
+#   ./delete-cloudhsm-keys-by-regex.sh                  # Delete all keys
+#   ./delete-cloudhsm-keys-by-regex.sh "^test-*"       # Delete keys starting with "test-"
+#   ./delete-cloudhsm-keys-by-regex.sh ".*-backup$"    # Delete keys ending with "-backup"
+#   ./delete-cloudhsm-keys-by-regex.sh "^mvgx-*"       # Delete keys starting with "mvgx-"
+
+set -eo pipefail
+
+# Default pattern to match all labels
+default_pattern=".*"
+# Get label pattern from command line argument, use default if no argument provided
+label_pattern="${1:-$default_pattern}"
+MAX_ITEMS=50
+STARTING_TOKEN=""
+
+# First, collect all matching key references with pagination
+echo "Step 1: Collecting all key references matching pattern: $label_pattern"
+all_key_refs=""
+
+while true; do
+  # Build the base command
+  CMD="cloudhsm-cli key list --max-items $MAX_ITEMS --verbose"
+  if [ -n "$STARTING_TOKEN" ]; then
+    CMD="$CMD --starting-token $STARTING_TOKEN"
+  fi
+
+  # Run the command and capture output
+  OUTPUT=$($CMD)
+
+  # Extract key references from keys with matching labels
+  batch_refs=$(echo "$OUTPUT" | jq -r --arg pattern "$label_pattern" '
+    .data.matched_keys[] | 
+    select(.attributes.label // "" | test($pattern)) | 
+    ."key-reference"
+  ')
+  
+  if [ -n "$batch_refs" ]; then
+    all_key_refs="$all_key_refs$batch_refs"$'\n'
+  fi
+
+  # Get the next_token from the output
+  NEXT_TOKEN=$(echo "$OUTPUT" | jq -r '.data.next_token // empty')
+
+  # Stop if there is no next_token
+  if [ -z "$NEXT_TOKEN" ]; then
+    break
+  fi
+
+  STARTING_TOKEN="$NEXT_TOKEN"
+done
+
+# Remove trailing newline and display found key references
+key_refs=$(echo "$all_key_refs" | sed '/^$/d')
+
+if [ -z "$key_refs" ]; then
+  echo "No keys found matching pattern: $label_pattern"
+  exit 0
+fi
+
+echo "Found $(echo "$key_refs" | wc -l) keys to delete"
+
+# Now delete keys directly using key references
+echo "Step 2: Deleting collected keys ..."
+while read -r key_ref; do
+  echo "Deleting key: $key_ref"
+  cloudhsm-cli key delete --filter key-reference="$key_ref"
+done <<< "$key_refs"
+
+echo "Deletion complete!"
+

--- a/security/cloudhsm-to-kms-keys-migration/docs/Quick Setup Guide for CloudHSM.md
+++ b/security/cloudhsm-to-kms-keys-migration/docs/Quick Setup Guide for CloudHSM.md
@@ -1,0 +1,385 @@
+# Quick Setup Guide for CloudHSM
+
+AWS CloudHSM provides robust hardware-based key storage for organizations requiring enhanced security and compliance in the cloud. This guide walks you through the step-by-step process of setting up a CloudHSM cluster in AWS, from creation to initialization and key management. By following these instructions, you'll establish a secure cryptographic infrastructure that can be integrated with your applications and AWS services.
+
+## Setup CloudHSM
+
+### Create and Initialize CloudHSM
+
+This step creates a CloudHSM cluster with 1 HSM instance in Singapore region.
+
+#### Step 1: Create CloudHSM Cluster
+
+Create a CloudHSM cluster and take note of its `ClusterId` value.
+
+```bash
+aws cloudhsmv2 create-cluster \
+--hsm-type hsm2m.medium \
+--mode FIPS \
+--subnet-ids subnet-09bb7fdaf05e437bf \
+--region ap-southeast-1
+```
+
+Result from the command.
+
+```json
+{
+	"Cluster": {
+		"BackupPolicy": "DEFAULT",
+		"BackupRetentionPolicy": {
+			"Type": "DAYS",
+			"Value": "90"
+		},
+		"ClusterId": "cluster-pgyrbxp7vpi",
+		"CreateTimestamp": "2025-07-11T15:38:38.603000+08:00",
+		"Hsms": [],
+		"HsmType": "hsm2m.medium",
+		"State": "CREATE_IN_PROGRESS",
+		"SubnetMapping": {
+			"ap-southeast-1a": "subnet-09bb7fdaf05e437bf"
+		},
+		"VpcId": "vpc-0544788d30aeff7a0",
+		"NetworkType": "IPV4",
+		"Certificates": {},
+		"Mode": "FIPS"
+	}
+}
+```
+
+#### Step 2: Create HSM in the Cluster
+
+Run following command twice to create a HSM instance in the cluster. Replace cluster-id with the correct cluster-id.
+
+```bash
+aws cloudhsmv2 create-hsm \
+--cluster-id cluster-pgyrbxp7vpi \
+--availability-zone ap-southeast-1a \
+--region ap-southeast-1
+```
+
+Result from the command.
+
+```json
+{
+	"Hsm": {
+		"AvailabilityZone": "ap-southeast-1a",
+		"ClusterId": "cluster-pgyrbxp7vpi",
+		"SubnetId": "subnet-09bb7fdaf05e437bf",
+		"HsmId": "hsm-bscclnb4rgc",
+		"HsmType": "hsm2m.medium",
+		"State": "CREATE_IN_PROGRESS"
+	}
+}
+```
+
+#### Step 3: Wait for the HSM to be Active
+
+Check the status of the cluster with following command. Replace the ClusterIds with value from previous step.
+
+```bash
+aws cloudhsmv2 describe-clusters --filters clusterIds=cluster-pgyrbxp7vpi --region ap-southeast-1
+```
+
+The cluster state is currently `UNINITIALIZED` and the HSM instance is in `ACTIVE` state. We will initialize the cluster in next few steps.
+
+```json
+{
+	...
+	"ClusterId": "cluster-pgyrbxp7vpi",
+	"CreateTimestamp": "2025-07-11T15:38:38.603000+08:00",
+	"Hsms": [
+		{
+			"AvailabilityZone": "ap-southeast-1a",
+			"ClusterId": "cluster-pgyrbxp7vpi",
+			"SubnetId": "subnet-09bb7fdaf05e437bf",
+			"EniId": "eni-02e9cefea8bdb2371",
+			"EniIp": "10.0.15.211",
+			"HsmId": "hsm-bscclnb4rgc",
+			"HsmType": "hsm2m.medium",
+			"State": "ACTIVE"
+		}
+	],
+	"HsmType": "hsm2m.medium",
+	"SecurityGroup": "sg-01b7eb8b5aebf0112",
+	"State": "UNINITIALIZED"
+	...
+}
+```
+
+#### Step 4: Create Certificate Authority for Cluster Initialization
+
+Create a self-signed certificate authority (CA).
+
+```bash
+openssl genrsa -out customerCA.key 2048
+openssl req -new -x509 -days 3652 -key customerCA.key -out customerCA.crt -subj "/CN=CloudHSM-CA/O=YourOrganization/C=SG"
+```
+
+#### Step 5: Get the Cluster's CSR and Sign It
+
+In following command, replace clusterId with your cluster ID. Get the CSR from the cluster, and sign the CSR with the CA from previous step.
+
+```bash
+aws cloudhsmv2 describe-clusters --filters clusterIds=cluster-pgyrbxp7vpi --query "Clusters[0].Certificates.ClusterCsr" --output text --region ap-southeast-1 > ClusterCsr.csr
+
+openssl x509 -req -days 3652 -in ClusterCsr.csr -CA customerCA.crt -CAkey customerCA.key -CAcreateserial -out CustomerHsmCertificate.crt
+```
+
+By now, here are the certificate files generated.
+
+```text
+-rw-r--r-- 1 ubuntu ubuntu 1026 Jul 11 09:59 ClusterCsr.csr
+-rw-r--r-- 1 ubuntu ubuntu   41 Jul 11 09:59 CustomerCA.srl
+-rw-r--r-- 1 ubuntu ubuntu 1281 Jul 11 09:59 CustomerHsmCertificate.crt
+-rw-r--r-- 1 ubuntu ubuntu 1229 Jul 11 09:59 customerCA.crt
+-rw------- 1 ubuntu ubuntu 1704 Jul 11 09:59 customerCA.key
+```
+
+#### Step 6: Initialize the Cluster with the Signed Certificate
+
+In following command, replace cluster-id with your cluster ID.
+
+```bash
+aws cloudhsmv2 initialize-cluster \
+--cluster-id cluster-pgyrbxp7vpi \
+--region ap-southeast-1 \
+--signed-cert file://CustomerHsmCertificate.crt \
+--trust-anchor file://customerCA.crt
+```
+
+Result:
+
+```json
+{
+	"State": "INITIALIZE_IN_PROGRESS",
+	"StateMessage": "Cluster is initializing. State will change to INITIALIZED upon completion."
+}
+```
+
+#### Step 7: Wait for Initialization to Complete
+
+Check the status of the cluster using following command. Update clusterIds with your cluster ID.
+
+```bash
+aws cloudhsmv2 describe-clusters --filters clusterIds=cluster-pgyrbxp7vpi --query "Clusters[0].[State,Hsms[0].State,Hsms[0].HsmId]" --region ap-southeast-1
+```
+
+Result:
+
+```json
+["INITIALIZE_IN_PROGRESS", "ACTIVE", "hsm-bscclnb4rgc"]
+```
+
+#### Step 8: Get HSM IP Address for Client Configuration
+
+```bash
+aws cloudhsmv2 describe-clusters --filters clusterIds=cluster-pgyrbxp7vpi --query "Clusters[0].Hsms[0].EniIp" --output text --region ap-southeast-1
+```
+
+Result:
+
+```
+10.0.15.211
+```
+
+### Activate CloudHSM Cluster
+
+We need to activate the CloudHSM cluster using CloudHSM CLI.
+
+#### Step 1: Install and Configure CloudHSM CLI
+
+Depends on your OS, you can download and install CloudHSM CLI by referring to this guide https://docs.aws.amazon.com/cloudhsm/latest/userguide/gs_cloudhsm_cli-install.html.
+
+Check the Ubuntu version
+
+```bash
+lsb_release -a
+```
+
+For example, for Ubuntu 24,
+
+1. Download installation file and install it.
+
+```sh
+wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/Noble/cloudhsm-cli_latest_u24.04_amd64.deb
+sudo apt install ./cloudhsm-cli_latest_u24.04_amd64.deb
+```
+
+2. Add `/opt/cloudhsm/bin` to path.
+
+```sh
+export PATH=$PATH:/opt/cloudhsm/bin
+```
+
+3. Specify the IP address of the HSM(s) in your cluster. Replace the IP with the IP of your HSM instance, which you get in previous step.
+
+```sh
+sudo /opt/cloudhsm/bin/configure-cli -a 10.0.15.211
+```
+
+#### Step 2: Activate the CloudHSM Cluster
+
+Reference: https://docs.aws.amazon.com/cloudhsm/latest/userguide/activate-cluster.html
+
+1. Make sure the EC2 instance you are in can connect to CloudHSM Instance at port 2223. If not, update the security group of CloudHSM cluster to allow access from EC2 IP at port 2223-2225.
+
+```
+nc -vz <CloudHSM_IP> 2223
+```
+
+2. Copy the issuing certificate `customerCA.crt` to the default location for cloudhsm-cli, i.e. the `/opt/cloudhsm/etc/` folder.
+
+```bash
+sudo cp customerCA.crt /opt/cloudhsm/etc/
+```
+
+3. Run following command to start interacting with CloudHSM cluster.
+
+```bash
+cloudhsm-cli interactive
+```
+
+#### Step 3: Activate CloudHSM Cluster
+
+We need to activate cluster before we can user it.
+
+1. CloudHSM comes with 2 default users, `admin` and `app_user`.
+
+```bash
+aws-cloudhsm > user list
+```
+
+2. We need to activate the cluster by setting password for `admin` user.
+
+```bash
+aws-cloudhsm > cluster activate
+```
+
+After this is done, the role of `admin` user will change from `"role": "unactivated-admin"` to `"role": "admin"`.
+
+3. Exit from cloudhsm-cli.
+
+```bash
+aws-cloudhsm > quit
+```
+
+## Working with CloudHSM using CloudHSM CLI
+
+### Create an user with `cryto-user` Role
+
+1. Login as admin user.
+
+```bash
+aws-cloudhsm > login --username admin --role admin
+```
+
+2. Create an user with `cryto-user` role.
+
+```bash
+aws-cloudhsm > user create --username user1 --role crypto-user
+```
+
+3. Quit from interactive terminal.
+
+```bash
+aws-cloudhsm > quit
+```
+
+### Use CloudHSM CLI in Bash
+
+Instead of using CloudHSM CLI in bash mode instead of interactive mode. We need to set CloudHSM username, password and role in the environment variables.
+
+1. Replace username and password accordingly.
+
+```
+export PATH=$PATH:/opt/cloudhsm/bin
+
+export CLOUDHSM_ROLE=crypto-user
+export CLOUDHSM_PIN="user1:Qwer1234"
+```
+
+2. Test the credential. Make sure it runs successfully.
+
+```bash
+cloudhsm-cli user list
+```
+
+### Create Sample Keys
+
+1. Create 20 sample keys each for `rsa` and `ec` types.
+
+```bash
+for i in {1..20}; do
+  cloudhsm-cli key generate-asymmetric-pair rsa \
+    --public-label "rsa-pub-$i" \
+    --private-label "rsa-priv-$i" \
+    --modulus-size-bits 2048 \
+    --public-exponent 65537;
+done
+```
+
+```bash
+for i in {1..20}; do
+  cloudhsm-cli key generate-asymmetric-pair ec \
+    --curve secp256k1 \
+    --public-label "ec-pub-$i" \
+    --private-label "ec-priv-$i";
+done
+```
+
+2. List sample same keys. Take note that `key list` command returns result in batch.
+
+```bash
+cloudhsm-cli key list
+```
+
+### Delete Keys by Label
+
+To delete a key, delete it by its `attributes.label` value.
+
+```bash
+cloudhsm-cli key delete --filter attr.label="$label"
+```
+
+List keys whose label matches a regex. Similarly, the returned key_labels is only a subset.
+
+```bash
+pattern="rsa-*"
+key_labels=$(cloudhsm-cli key list --verbose | jq -r '.data.matched_keys[].attributes.label' | grep -E "$pattern")
+echo $key_labels
+
+while read -r label; do
+	cloudhsm-cli key delete --filter attr.label="$label"
+done <<< "$key_labels"
+```
+
+## Clean Up CloudHSM Cluster
+
+1. List all HSM instances ID in the cluster.
+
+```bash
+aws cloudhsmv2 describe-clusters --filters clusterIds=cluster-pgyrbxp7vpi --region ap-southeast-1
+```
+
+2. Delete the HSM instance one by one.
+
+```bash
+# Delete the CloudHSM cluster (must delete HSM instances first)
+aws cloudhsmv2 delete-hsm \
+--cluster-id cluster-fhtbm47tsjo \
+--hsm-id hsm-7qsltqrczv5 \
+--region ap-southeast-1
+```
+
+3. Delete the cluster
+
+```bash
+# Delete cluster
+aws cloudhsmv2 delete-cluster \
+--cluster-id cluster-fhtbm47tsjo \
+--region ap-southeast-1
+```
+
+## Conclusion
+
+Setting up AWS CloudHSM might seem complex, but this guide breaks down the process into manageable steps. You've learned how to create and initialize a CloudHSM cluster, configure the necessary certificates, manage users, and work with cryptographic keys. Remember to clean up your resources when they're no longer needed to avoid unnecessary costs. With your CloudHSM environment now operational, you have a secure foundation for implementing cryptographic operations in your AWS workloads while maintaining control over your encryption keys.

--- a/security/cloudhsm-to-kms-keys-migration/generate-cloudhsm-test-keys.sh
+++ b/security/cloudhsm-to-kms-keys-migration/generate-cloudhsm-test-keys.sh
@@ -1,0 +1,19 @@
+for i in {1..20}; do
+	cloudhsm-cli key generate-asymmetric-pair ec \
+		--public-label "mvgx-ec-pub-$i" \
+		--private-label "mvgx-ec-priv-$i" \
+		--curve secp256k1 \
+		--public-attributes encrypt=true verify=true \
+		--private-attributes decrypt=true sign=true 
+done
+
+for i in {1..20}; do
+  cloudhsm-cli key generate-asymmetric-pair rsa \
+    --public-label "mvgx-rsa-pub-$i" \
+    --private-label "mvgx-rsa-priv-$i" \
+    --modulus-size-bits 2048 \
+    --public-exponent 65537 \
+		--public-attributes encrypt=true verify=true \
+		--private-attributes decrypt=true sign=true 		
+done
+

--- a/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-keys.sh
+++ b/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-keys.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Lists CloudHSM keys (private or public) matching a regex pattern on their labels.
+# Paginates through all keys in CloudHSM, filters by configurable label pattern,
+# and outputs results to a JSON file as a proper JSON array.
+#
+# Usage:
+#   ./list-cloudhsm-keys.sh [KEY_CLASS] [OUTPUT_FILE] [PATTERN]
+#
+# Arguments:
+#   KEY_CLASS    - Type of keys to list: "private-key" or "public-key" (default: "private-key")
+#   OUTPUT_FILE  - Output JSON file path (default: "private_keys.json")
+#   PATTERN      - Regex pattern to match key labels (default: ".*" matches all)
+#
+# Examples:
+#   ./list-cloudhsm-keys.sh                                               # List all private keys to private_keys.json
+#   ./list-cloudhsm-keys.sh public-key                                    # List all public keys to private_keys.json
+#   ./list-cloudhsm-keys.sh private-key "my_keys.json"                    # List private keys to my_keys.json
+#   ./list-cloudhsm-keys.sh public-key "test_keys.json" "^mvgx-*"         # List public keys starting with "mvgx-" to test_keys.json
+#   ./list-cloudhsm-keys.sh private-key "backup_keys.json" ".*"           # List all private keys to backup_keys.json
+
+set -eo pipefail
+export PATH=$PATH:/opt/cloudhsm/bin
+
+# Set defaults
+default_key_class="private-key"
+default_pattern=".*"
+default_output_file="private_keys.json"
+
+# Get KEY_CLASS from 1st argument with default
+KEY_CLASS="${1:-$default_key_class}"
+
+# Validate KEY_CLASS
+if [ "$KEY_CLASS" != "private-key" ] && [ "$KEY_CLASS" != "public-key" ]; then
+    echo "Error: KEY_CLASS must be 'private-key' or 'public-key', got '$KEY_CLASS'"
+    exit 1
+fi
+
+# Get output file from 2nd command line argument, use default if no argument provided
+OUTPUT_FILE="${2:-$default_output_file}"
+# Get label pattern from 3rd command line argument, use default if no argument provided
+label_pattern="${3:-$default_pattern}"
+
+MAX_ITEMS=10
+STARTING_TOKEN=""
+FIRST_RUN=true
+
+echo "Searching for $KEY_CLASS keys matching pattern: $label_pattern"
+echo "Output will be saved to: $OUTPUT_FILE"
+
+# Empty the output file before starting
+> "$OUTPUT_FILE"
+
+while true; do
+  # Build the base command
+  CMD="cloudhsm-cli key list --filter attr.class=$KEY_CLASS --verbose --max-items $MAX_ITEMS"
+  if [ -n "$STARTING_TOKEN" ]; then
+    CMD="$CMD --starting-token $STARTING_TOKEN"
+  fi
+
+  # Run the command and capture output
+  OUTPUT=$($CMD)
+
+  # Filter keys by label pattern and save to file
+  if $FIRST_RUN; then
+    # For first run, create the initial structure with filtered keys
+    echo "$OUTPUT" | jq --arg pattern "$label_pattern" '
+      .data.matched_keys |= map(select(.attributes.label // "" | test($pattern)))
+    ' > "$OUTPUT_FILE"
+    FIRST_RUN=false
+  else
+    # For subsequent runs, append filtered keys to matched_keys array
+    FILTERED_KEYS=$(echo "$OUTPUT" | jq --arg pattern "$label_pattern" '
+      .data.matched_keys | map(select(.attributes.label // "" | test($pattern)))
+    ')
+    
+    # Only update if there are filtered keys
+    if [ "$(echo "$FILTERED_KEYS" | jq 'length')" -gt 0 ]; then
+      jq --argjson new_keys "$FILTERED_KEYS" '.data.matched_keys += $new_keys' "$OUTPUT_FILE" > "$OUTPUT_FILE.tmp" && mv "$OUTPUT_FILE.tmp" "$OUTPUT_FILE"
+    fi
+  fi
+
+  # Get the next_token from the output
+  NEXT_TOKEN=$(echo "$OUTPUT" | jq -r '.data.next_token // empty')
+
+  # Stop if there is no next_token
+  if [ -z "$NEXT_TOKEN" ]; then
+    break
+  fi
+
+  STARTING_TOKEN="$NEXT_TOKEN"
+done
+
+# Report results
+KEY_COUNT=$(jq '.data.matched_keys | length' "$OUTPUT_FILE")
+echo "Found $KEY_COUNT $KEY_CLASS keys matching pattern '$label_pattern' saved to $OUTPUT_FILE"

--- a/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-private-keys.sh
+++ b/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-private-keys.sh
@@ -1,0 +1,34 @@
+
+#!/bin/bash
+
+# Lists CloudHSM private keys matching a regex pattern on their labels.
+# This is a wrapper script that calls list-cloudhsm-keys.sh for backward compatibility.
+#
+# Usage:
+#   ./list-cloudhsm-private-keys.sh [PATTERN] [OUTPUT_FILE]
+#
+# Arguments:
+#   PATTERN      - Regex pattern to match key labels (default: ".*" matches all)
+#   OUTPUT_FILE  - Output JSON file path (default: "private_keys.json")
+#
+# Examples:
+#   ./list-cloudhsm-private-keys.sh                            # List all private keys to private_keys.json
+#   ./list-cloudhsm-private-keys.sh "^mvgx-*"                  # List keys starting with "mvgx-"
+#   ./list-cloudhsm-private-keys.sh "test.*" "test_keys.json"  # List test keys to custom file
+#   ./list-cloudhsm-private-keys.sh ".*" "backup_keys.json"    # List all keys to backup file
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set defaults for private keys
+default_pattern=".*"
+default_output_file="private_keys.json"
+
+# Get arguments with defaults
+PATTERN="${1:-$default_pattern}"
+OUTPUT_FILE="${2:-$default_output_file}"
+
+# Call the unified script: list-cloudhsm-keys.sh [KEY_CLASS] [OUTPUT_FILE] [PATTERN]
+exec "$SCRIPT_DIR/list-cloudhsm-keys.sh" "private-key" "$OUTPUT_FILE" "$PATTERN"
+
+

--- a/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-public-keys.sh
+++ b/security/cloudhsm-to-kms-keys-migration/list-cloudhsm-public-keys.sh
@@ -1,0 +1,34 @@
+
+#!/bin/bash
+
+# Lists CloudHSM public keys matching a regex pattern on their labels.
+# This is a wrapper script that calls list-cloudhsm-keys.sh for backward compatibility.
+#
+# Usage:
+#   ./list-cloudhsm-public-keys.sh [PATTERN] [OUTPUT_FILE]
+#
+# Arguments:
+#   PATTERN      - Regex pattern to match key labels (default: ".*" matches all)
+#   OUTPUT_FILE  - Output JSON file path (default: "public_keys.json")
+#
+# Examples:
+#   ./list-cloudhsm-public-keys.sh                           # List all public keys to public_keys.json
+#   ./list-cloudhsm-public-keys.sh "^mvgx-*"                 # List keys starting with "mvgx-"
+#   ./list-cloudhsm-public-keys.sh "test.*" "test_keys.json" # List test keys to custom file
+#   ./list-cloudhsm-public-keys.sh ".*" "backup_keys.json"   # List all keys to backup file
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set defaults for public keys
+default_pattern=".*"
+default_output_file="public_keys.json"
+
+# Get arguments with defaults
+PATTERN="${1:-$default_pattern}"
+OUTPUT_FILE="${2:-$default_output_file}"
+
+# Call the unified script: list-cloudhsm-keys.sh [KEY_CLASS] [OUTPUT_FILE] [PATTERN]
+exec "$SCRIPT_DIR/list-cloudhsm-keys.sh" "public-key" "$OUTPUT_FILE" "$PATTERN"
+
+

--- a/security/cloudhsm-to-kms-keys-migration/migrate-cloudhsm-ec-keys-to-kms.sh
+++ b/security/cloudhsm-to-kms-keys-migration/migrate-cloudhsm-ec-keys-to-kms.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+set -eo pipefail
+
+export PATH=$PATH:/opt/cloudhsm/bin
+
+# CloudHSM config
+PRIVATE_KEYS_FILE="${1:-private_keys.json}"
+# PUBLIC_KEYS_FILE="${2:-public_keys.json}"
+
+# Create staging directory for intermediate files
+STAGING_DIR="staging"
+mkdir -p $STAGING_DIR
+
+TIMESTAMP="$(date '+%Y%m%d_%H%M')"
+FILENAME="${PRIVATE_KEYS_FILE##*/}"      # Gets just the filename
+FILENAME_NO_EXT="${FILENAME%.*}"         # Removes the extension
+RESULT_FILE_KEYS_FAILED="result_failed_${FILENAME_NO_EXT%.*}_$TIMESTAMP.txt"
+RESULT_FILE_KEYS_SUCCESS="result_success_${FILENAME_NO_EXT%.*}_$TIMESTAMP.txt"
+
+# Create log file with timestamp
+LOG_FILE="log_$TIMESTAMP.log"
+
+# Setup result files
+# echo "CloudHSM_KEY_REF,CLOUDHSM_KEY_LABEL,REASON" > $RESULT_FILE_KEYS_FAILED
+# echo "CloudHSM_KEY_REF,CLOUDHSM_KEY_LABEL,KMS_KEY_ID" > $RESULT_FILE_KEYS_SUCCESS
+
+# Process each EC private key only
+jq -c '.data.matched_keys[] | select(.attributes["key-type"] == "ec")' $PRIVATE_KEYS_FILE | while read -r KEY; do
+    # Extract key details    
+    # KEY_REF: Private key key-reference value
+    KEY_REF=$(echo $KEY | jq -r '."key-reference"')
+    # KEY_LABEL: Private key attributes.label value
+    KEY_LABEL=$(echo $KEY | jq -r '.attributes.label')
+    # EC_POINT: Private key attribute.ec-point value, which will be used to find respective public key key-reference
+    # KEY_EC_POINT=$(echo $KEY | jq -r '.attributes.["ec-point"]')
+    # CURVE: Private key attribute.curve value, which will be used to determine KMS key spec
+    KEY_CURVE=$(echo $KEY | jq -r '.attributes.curve')
+
+    echo "CloudHSM Key: $KEY_LABEL, $KEY_REF ---------"
+    echo "----------------------------------------------" >> $LOG_FILE
+    echo "CloudHSM Key: $KEY_LABEL, $KEY_REF, $KEY_CURVE" >> $LOG_FILE
+
+    # # Step 0: Skip if corresponding public key not exists
+    # PUBLIC_KEY_REF=$(cat $PUBLIC_KEYS_FILE | jq -r --arg EC_POINT "$KEY_EC_POINT" '.data.matched_keys[] | select(.attributes."ec-point" == $EC_POINT) | ."key-reference"')
+    
+    # if [ "$PUBLIC_KEY_REF" = "null" ] || [ -z "$PUBLIC_KEY_REF" ]; then
+    #     echo "  No corresponding public key found"
+    #     echo "No corresponding public key found in $PUBLIC_KEYS_FILE, skipping key $KEY_REF" >> $LOG_FILE
+    #     echo $KEY_REF,$KEY_LABEL,"No corresponding public key found" >> $RESULT_FILE_KEYS_FAILED
+    #     continue
+    # fi
+
+    # Step 1: Create KMS key for ECC
+    # Determine key spec based on curve
+    if [ "$KEY_CURVE" = "secp256k1" ]; then
+        KEY_SPEC="ECC_SECG_P256K1"
+    elif [ "$KEY_CURVE" = "prime256v1" ] || [ "$KEY_CURVE" = "secp256r1" ]; then
+        KEY_SPEC="ECC_NIST_P256"
+    else
+        echo "Unsupported curve: $KEY_CURVE for key $KEY_REF" >> $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,"Unsupported curve: $KEY_CURVE for key $KEY_REF" >> $RESULT_FILE_KEYS_FAILED
+        continue
+    fi
+    
+    echo "Using key spec $KEY_SPEC for curve $KEY_CURVE" >> $LOG_FILE
+    KMS_KEY_ID=$(aws kms create-key --origin EXTERNAL --key-spec $KEY_SPEC --key-usage SIGN_VERIFY \
+        --description "Imported from CloudHSM: $KEY_LABEL" \
+        --query 'KeyMetadata.KeyId' --output text 2>> $LOG_FILE)
+    echo "Created KMS key: $KMS_KEY_ID" >> $LOG_FILE
+    echo "  KMS Key: $KMS_KEY_ID"
+
+    # Step 2: Get wrapping parameters and save to named files
+    WRAPPING_PUBLIC_KEY_B64="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.b64"
+    WRAPPING_PUBLIC_KEY_BIN="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.bin"
+    WRAPPING_PUBLIC_KEY_PEM="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.pem"
+    IMPORT_TOKEN_B64="$STAGING_DIR/${KEY_REF}_ImportToken.b64"
+    IMPORT_TOKEN_BIN="$STAGING_DIR/${KEY_REF}_ImportToken.bin"
+    
+    # Save wrapping key parameters to files
+    #  Wrapping is always RSA-based regardless of the target key type being imported
+    aws kms get-parameters-for-import \
+        --key-id "$KMS_KEY_ID" \
+        --wrapping-algorithm RSAES_OAEP_SHA_256 \
+        --wrapping-key-spec RSA_4096 \
+        --query "[ImportToken, PublicKey]" \
+        --output text 2>> $LOG_FILE \
+        | awk '{print $1 > "'$IMPORT_TOKEN_B64'"; print $2 > "'$WRAPPING_PUBLIC_KEY_B64'"}'
+
+    echo "Saved wrapping parameters to $WRAPPING_PUBLIC_KEY_B64 and $IMPORT_TOKEN_B64" >> $LOG_FILE
+
+    # decode the token from base64 to binary format before it can be used
+    openssl enc -d -base64 -A -in $IMPORT_TOKEN_B64 -out $IMPORT_TOKEN_BIN 2>> $LOG_FILE
+
+    # Decode the base64 encoding to binary DER format
+    openssl enc -d -base64 -A -in $WRAPPING_PUBLIC_KEY_B64 -out $WRAPPING_PUBLIC_KEY_BIN 2>> $LOG_FILE
+    
+    # Convert the wrapping public key from DER to PEM format
+    openssl rsa -pubin -in $WRAPPING_PUBLIC_KEY_BIN -inform DER -outform PEM -out $WRAPPING_PUBLIC_KEY_PEM 2>> $LOG_FILE
+    
+    echo "Converted wrapping key to PEM format: $WRAPPING_PUBLIC_KEY_PEM" >> $LOG_FILE
+
+    # Step 3: Import wrapping key to CloudHSM
+    WRAP_LABEL="kms_wrapping_key_for_${KEY_REF}"
+    
+    # Import the wrapping key
+    import_key_output=$(cloudhsm-cli key import pem --path $WRAPPING_PUBLIC_KEY_PEM --label $WRAP_LABEL --key-type-class rsa-public --attributes wrap=true 2>> $LOG_FILE)
+    WRAP_KEY_REF=$(echo "$import_key_output" | jq -r '.data.key["key-reference"]')
+    echo "$import_key_output" >> $LOG_FILE
+
+    echo "Imported wrapping key to CloudHSM with label = $WRAP_LABEL, key-reference = $WRAP_KEY_REF" >> $LOG_FILE
+
+    # Step 4: Wrap the private key inside CloudHSM
+    WRAPPED_KEY_FILE="$STAGING_DIR/${KEY_REF}_EncryptedKeyMaterial.bin"
+
+    cloudhsm-cli key wrap rsa-oaep \
+        --payload-filter "key-reference=$KEY_REF" \
+        --wrapping-filter "key-reference=$WRAP_KEY_REF" \
+        --hash-function sha256 --mgf mgf1-sha256 \
+        --path $WRAPPED_KEY_FILE >> $LOG_FILE 2>&1
+    
+    echo "Wrapped key saved to: $WRAPPED_KEY_FILE" >> $LOG_FILE
+    
+    # Step 5: Import to KMS
+    aws kms import-key-material \
+        --key-id $KMS_KEY_ID \
+        --encrypted-key-material fileb://$WRAPPED_KEY_FILE \
+        --import-token fileb://$IMPORT_TOKEN_BIN \
+        --expiration-model KEY_MATERIAL_DOES_NOT_EXPIRE >> $LOG_FILE 2>&1
+
+    echo "Successfully imported key $KEY_LABEL to KMS key $KMS_KEY_ID" >> $LOG_FILE
+
+    # Wait for key to become enabled
+    echo "Waiting for key to become enabled..."
+    while true; do
+        KEY_STATE=$(aws kms describe-key --key-id $KMS_KEY_ID --query 'KeyMetadata.KeyState' --output text)
+        echo "Key state: $KEY_STATE"
+        if [ "$KEY_STATE" = "Enabled" ]; then
+            # Additional wait to ensure key is fully ready for operations
+            sleep 5
+            break
+        elif [ "$KEY_STATE" = "PendingImport" ]; then
+            sleep 2
+        else
+            echo "Unexpected key state: $KEY_STATE"
+            echo $KEY_REF,$KEY_LABEL,"Key import failed - state: $KEY_STATE" >> $RESULT_FILE_KEYS_FAILED
+            continue 2  # Skip to next key
+        fi
+    done
+
+    # Step 6: Test Keys in KMS using Public Key in CloudHSM
+
+    ### Sign Test Message with CloudHSM ###
+    # Create a simple message and encode it in base64 in a text file
+    echo -n 'Hello World' > message.txt
+    # cat message.txt | openssl base64 -out message_base64.txt
+
+    # Sign using CloudHSM private key
+    echo "Signing using CloudHSM private key..."
+    # signature.sig contains base64-encoded signature; signaturee.bin contains binary signature
+    cloudhsm-cli crypto sign ecdsa --key-filter "key-reference=$KEY_REF" --hash-function sha256 --data-path message.txt --data-type raw | jq -r '.data.signature' > signature.sig
+    # Decode the base64 signature to binary format
+    openssl enc -d -base64 -in signature.sig -out signature.bin
+
+    # # Option 1: Verify using CloudHSM public key
+    # cloudhsm-cli crypto verify ecdsa --key-filter "key-reference=$PUBLIC_KEY_REF" --hash-function sha256 --data-path message.txt --signature-path signature.bin --data-type raw > verification.txt
+    # # Check verification result
+    # result=$( [ "$(jq -r '.error_code' verification.txt)" -eq 0 ] && echo "success" || echo "failure" )
+    # echo "Verification using CloudHSM public key: $result"
+
+    # # Option 2: Verify using OpenSSL and PEM file from CloudHSM public key
+    # # Convert raw signature to DER format for OpenSSL
+    openssl asn1parse -genconf <(echo -e "asn1=SEQUENCE:sig\n[sig]\nr=INTEGER:0x$(head -c 32 signature.bin | xxd -p -c 32)\ns=INTEGER:0x$(tail -c 32 signature.bin | xxd -p -c 32)") -out signature.der
+    # # Export public key to PEM
+    # cloudhsm-cli key generate-file --encoding pem --path public_key_cloudhsm.pem --filter "key-reference=$PUBLIC_KEY_REF"
+    # # Verify using PEM file and DER signature
+    # openssl dgst -sha256 -verify public_key_cloudhsm.pem -signature signature.der message.txt > verification.txt
+    # result=$(grep -q "Verified OK" verification.txt && echo "success" || echo "failure")
+    # echo "Verification using PEM of CloudHSM public key: $result"
+
+    # Option 3: Verify using KMS Public Key with retry logic
+    result="failure"
+    max_attempts=5
+    for attempt in $(seq 1 $max_attempts); do
+        echo "Verification attempt $attempt/$max_attempts using KMS public key..."
+        
+        if aws kms verify --key-id $KMS_KEY_ID --message fileb://message.txt --message-type RAW --signing-algorithm ECDSA_SHA_256 --signature fileb://signature.der --output json > verification.txt 2>&1; then
+            result=$(cat verification.txt | jq -r 'if .SignatureValid then "success" else "failure" end')
+            echo "Verification using KMS public key: $result"
+            break
+        else
+            if grep -qi "pending import\|invalid.*state" verification.txt; then
+                echo "Key still not ready for operations, waiting and retrying..."
+                sleep $((attempt * 3))  # Exponential backoff: 3, 6, 9, 12, 15 seconds
+            else
+                echo "Verification failed with error:"
+                cat verification.txt
+                break
+            fi
+        fi
+        
+        if [ $attempt -eq $max_attempts ]; then
+            echo "Max retry attempts reached, verification failed"
+            result="failure"
+        fi
+    done
+
+    # # Option 4: Verify using OpenSSL and PEM file from KMS public key
+    # aws kms get-public-key --key-id $KMS_KEY_ID --query 'PublicKey' --output text | base64 --decode > public_key.der
+    # # Convert public key from KMS in DER (binary) format to PEM (Base64-encoded), use OpenSSL
+    # openssl ec -pubin -inform DER -in public_key.der -outform PEM -out public_key.pem
+    # openssl dgst -sha256 -verify public_key.pem -signature signature.der message.txt > verification.txt
+    # result=$(grep -q "Verified OK" verification.txt && echo "success" || echo "failure")
+    # echo "Verification using PEM of KMS public key: $result"
+
+    # Step 7: Save results to CSV file
+    if [ "$result" != "success" ]; then
+        echo "FAILED to process CloudHSM key $KEY_REF, $KEY_LABEL" | tee -a $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,"Verification failed: $result" >> $RESULT_FILE_KEYS_FAILED
+    else
+        echo "SUCCEED to process CloudHSM key $KEY_REF, $KEY_LABEL" | tee -a $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,$KMS_KEY_ID >> $RESULT_FILE_KEYS_SUCCESS
+    fi
+
+done
+
+# Count results
+SUCCESSFUL_COUNT=0
+FAILED_COUNT=0
+
+if [ -f "$RESULT_FILE_KEYS_SUCCESS" ]; then
+    SUCCESSFUL_COUNT=$(wc -l < "$RESULT_FILE_KEYS_SUCCESS" | tr -d ' ')
+fi
+
+if [ -f "$RESULT_FILE_KEYS_FAILED" ]; then
+    FAILED_COUNT=$(wc -l < "$RESULT_FILE_KEYS_FAILED" | tr -d ' ')
+fi
+
+echo "------ Migration Complete: $SUCCESSFUL_COUNT successful, $FAILED_COUNT failed --------" | tee -a $LOG_FILE
+
+

--- a/security/cloudhsm-to-kms-keys-migration/migrate-cloudhsm-rsa-keys-to-kms.sh
+++ b/security/cloudhsm-to-kms-keys-migration/migrate-cloudhsm-rsa-keys-to-kms.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+set -eo pipefail
+
+export PATH=$PATH:/opt/cloudhsm/bin
+
+# CloudHSM config
+PRIVATE_KEYS_FILE="${1:-private_keys.json}"
+# PUBLIC_KEYS_FILE="${2:-public_keys.json}"
+
+# Create staging directory for intermediate files
+STAGING_DIR="staging"
+mkdir -p $STAGING_DIR
+
+TIMESTAMP="$(date '+%Y%m%d_%H%M')"
+FILENAME="${PRIVATE_KEYS_FILE##*/}"      # Gets just the filename
+FILENAME_NO_EXT="${FILENAME%.*}"         # Removes the extension
+RESULT_FILE_KEYS_FAILED="result_failed_${FILENAME_NO_EXT%.*}_$TIMESTAMP.txt"
+RESULT_FILE_KEYS_SUCCESS="result_success_${FILENAME_NO_EXT%.*}_$TIMESTAMP.txt"
+
+# Create log file with timestamp
+LOG_FILE="log_$TIMESTAMP.log"
+
+# Setup result files
+# echo "CloudHSM_KEY_REF,CLOUDHSM_KEY_LABEL,REASON" > $RESULT_FILE_KEYS_FAILED
+# echo "CloudHSM_KEY_REF,CLOUDHSM_KEY_LABEL,KMS_KEY_ID" > $RESULT_FILE_KEYS_SUCCESS
+
+# Process each RSA private key only
+jq -c '.data.matched_keys[] | select(.attributes["key-type"] == "rsa")' $PRIVATE_KEYS_FILE | while read -r KEY; do
+    # Extract key details    
+    # KEY_REF: Private key key-reference value
+    KEY_REF=$(echo $KEY | jq -r '."key-reference"')
+    # KEY_LABEL: Private key attributes.label value
+    KEY_LABEL=$(echo $KEY | jq -r '.attributes.label')
+    # MODULUS: Private key attribute.modulus value, which will be used to find respective public key key-reference
+    KEY_MODULUS=$(echo $KEY | jq -r '.attributes.modulus')
+    # MODULUS_SIZE: Private key attribute modulus size in bits
+    KEY_MODULUS_SIZE=$(echo $KEY | jq -r '.attributes."modulus-size-bits"')
+
+    # Sample values for TESTING
+    # KEY_REF=0x0000000000040da2
+    # KEY_LABEL=mvgx-rsa-priv-20
+    # KEY_MODULUS=0x00c2b5a...
+
+    echo "CloudHSM Key: $KEY_LABEL, $KEY_REF ---------"
+    echo "----------------------------------------------" >> $LOG_FILE
+    echo "CloudHSM Key: $KEY_LABEL, $KEY_REF, RSA-$KEY_MODULUS_SIZE" >> $LOG_FILE
+
+    # # Step 0: Skip if corresponding public key exists
+    # PUBLIC_KEY_REF=$(cat $PUBLIC_KEYS_FILE | jq -r --arg MODULUS "$KEY_MODULUS" '.data.matched_keys[] | select(.attributes.modulus == $MODULUS) | ."key-reference"')
+    
+    # if [ "$PUBLIC_KEY_REF" = "null" ] || [ -z "$PUBLIC_KEY_REF" ]; then
+    #     echo "  No corresponding public key found"
+    #     echo "No corresponding public key found in $PUBLIC_KEYS_FILE, skipping key $KEY_REF" >> $LOG_FILE
+    #     echo $KEY_REF,$KEY_LABEL,"No corresponding public key found" >> $RESULT_FILE_KEYS_FAILED
+    #     continue
+    # fi
+
+    # Step 1: Create KMS key for RSA
+    # Determine key spec based on modulus size
+    if [ "$KEY_MODULUS_SIZE" = "2048" ]; then
+        KEY_SPEC="RSA_2048"
+    elif [ "$KEY_MODULUS_SIZE" = "3072" ]; then
+        KEY_SPEC="RSA_3072"
+    elif [ "$KEY_MODULUS_SIZE" = "4096" ]; then
+        KEY_SPEC="RSA_4096"
+    else
+        echo "  Unsupported RSA key size: $KEY_MODULUS_SIZE"
+        echo "Unsupported RSA key size: $KEY_MODULUS_SIZE for key $KEY_REF" >> $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,"Unsupported RSA key size: $KEY_MODULUS_SIZE" >> $RESULT_FILE_KEYS_FAILED
+        continue
+    fi
+    
+    echo "Using key spec $KEY_SPEC for RSA-$KEY_MODULUS_SIZE" >> $LOG_FILE
+    KMS_KEY_ID=$(aws kms create-key --origin EXTERNAL --key-spec $KEY_SPEC --key-usage SIGN_VERIFY \
+        --description "Imported from CloudHSM: $KEY_LABEL" \
+        --query 'KeyMetadata.KeyId' --output text 2>> $LOG_FILE)
+    echo "Created KMS key: $KMS_KEY_ID" >> $LOG_FILE
+    echo "  KMS Key: $KMS_KEY_ID"
+
+    # Step 2: Get wrapping parameters and save to named files
+    WRAPPING_PUBLIC_KEY_B64="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.b64"
+    WRAPPING_PUBLIC_KEY_BIN="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.bin"
+    WRAPPING_PUBLIC_KEY_PEM="$STAGING_DIR/${KEY_REF}_WrappingPublicKey.pem"
+    IMPORT_TOKEN_B64="$STAGING_DIR/${KEY_REF}_ImportToken.b64"
+    IMPORT_TOKEN_BIN="$STAGING_DIR/${KEY_REF}_ImportToken.bin"
+    
+    # Save wrapping key parameters to files
+    #  Wrapping is always RSA-based regardless of the target key type being imported
+    aws kms get-parameters-for-import \
+        --key-id "$KMS_KEY_ID" \
+        --wrapping-algorithm RSA_AES_KEY_WRAP_SHA_256 \
+        --wrapping-key-spec RSA_2048 \
+        --query "[ImportToken, PublicKey]" \
+        --output text 2>> $LOG_FILE \
+        | awk '{print $1 > "'$IMPORT_TOKEN_B64'"; print $2 > "'$WRAPPING_PUBLIC_KEY_B64'"}'
+
+    echo "Saved wrapping parameters to $WRAPPING_PUBLIC_KEY_B64 and $IMPORT_TOKEN_B64" >> $LOG_FILE
+
+    # decode the token from base64 to binary format before it can be used
+    openssl enc -d -base64 -A -in $IMPORT_TOKEN_B64 -out $IMPORT_TOKEN_BIN 2>> $LOG_FILE
+
+    # Decode the base64 encoding to binary DER format
+    openssl enc -d -base64 -A -in $WRAPPING_PUBLIC_KEY_B64 -out $WRAPPING_PUBLIC_KEY_BIN 2>> $LOG_FILE
+    
+    # Convert the wrapping public key from DER to PEM format
+    openssl rsa -pubin -in $WRAPPING_PUBLIC_KEY_BIN -inform DER -outform PEM -out $WRAPPING_PUBLIC_KEY_PEM 2>> $LOG_FILE
+    
+    echo "Converted wrapping key to PEM format: $WRAPPING_PUBLIC_KEY_PEM" >> $LOG_FILE
+
+    # Step 3: Import wrapping key to CloudHSM
+    WRAP_LABEL="kms_wrapping_key_for_${KEY_REF}"
+    
+    # Import the wrapping key
+    import_key_output=$(cloudhsm-cli key import pem --path $WRAPPING_PUBLIC_KEY_PEM --label $WRAP_LABEL --key-type-class rsa-public --attributes wrap=true 2>> $LOG_FILE)
+    WRAP_KEY_REF=$(echo "$import_key_output" | jq -r '.data.key["key-reference"]')
+    echo "$import_key_output" >> $LOG_FILE
+
+    echo "Imported wrapping key to CloudHSM with label = $WRAP_LABEL, key-reference = $WRAP_KEY_REF" >> $LOG_FILE
+
+    # Step 4: Wrap the private key inside CloudHSM
+    WRAPPED_KEY_FILE="$STAGING_DIR/${KEY_REF}_EncryptedKeyMaterial.bin"
+
+    cloudhsm-cli key wrap rsa-aes \
+        --payload-filter "key-reference=$KEY_REF" \
+        --wrapping-filter "key-reference=$WRAP_KEY_REF" \
+        --hash-function sha256 --mgf mgf1-sha256 \
+        --path $WRAPPED_KEY_FILE >> $LOG_FILE 2>&1
+    
+    echo "Wrapped key saved to: $WRAPPED_KEY_FILE" >> $LOG_FILE
+    
+    # Step 5: Import to KMS
+    aws kms import-key-material \
+        --key-id $KMS_KEY_ID \
+        --encrypted-key-material fileb://$WRAPPED_KEY_FILE \
+        --import-token fileb://$IMPORT_TOKEN_BIN \
+        --expiration-model KEY_MATERIAL_DOES_NOT_EXPIRE >> $LOG_FILE 2>&1
+
+    echo "Successfully imported key $KEY_LABEL to KMS key $KMS_KEY_ID" >> $LOG_FILE
+
+    # Wait for key to become enabled
+    echo "Waiting for key to become enabled..."
+    while true; do
+        KEY_STATE=$(aws kms describe-key --key-id $KMS_KEY_ID --query 'KeyMetadata.KeyState' --output text)
+        echo "Key state: $KEY_STATE"
+        if [ "$KEY_STATE" = "Enabled" ]; then
+            break
+        elif [ "$KEY_STATE" = "PendingImport" ]; then
+            sleep 2
+        else
+            echo "Unexpected key state: $KEY_STATE"
+            echo $KEY_REF,$KEY_LABEL,"Key import failed - 
+    state: $KEY_STATE" >> $RESULT_FILE_KEYS_FAILED
+            continue 2  # Skip to next key
+        fi
+    done
+
+    # Step 6: Test Keys in KMS using Public Key in CloudHSM
+
+    ### Sign Test Message with CloudHSM ###
+    # Create a simple message (raw text, not base64)
+    echo -n 'Hello World' > message.txt
+    # cat message.txt | openssl base64 -out message_base64.txt
+
+    # Sign using CloudHSM private key
+    echo "Signing using CloudHSM private key..."
+    # signature.sig contains base64-encoded signature; signature.bin contains binary signature
+    cloudhsm-cli crypto sign rsa-pkcs --key-filter "key-reference=$KEY_REF" --hash-function sha256 --data-path message.txt --data-type raw | jq -r '.data.signature' > signature.sig
+    # Decode the base64 signature to binary format
+    openssl enc -d -base64 -in signature.sig -out signature.bin
+
+    # # Option 1: Verify using CloudHSM public key
+    # cloudhsm-cli crypto verify rsa-pkcs --key-filter "key-reference=$PUBLIC_KEY_REF" --hash-function sha256 --data-path message.txt --signature-path signature.bin --data-type raw > verification.txt 2>&1
+    # # Check verification result
+    # result=$( [ "$(jq -r '.error_code // 1' verification.txt 2>/dev/null || echo 1)" -eq 0 ] && echo "success" || echo "failure" )
+    # echo "Verification using CloudHSM public key: $result"
+
+    # # Option 2: Verify using OpenSSL and PEM file from CloudHSM public key
+    # # Export public key to PEM
+    # cloudhsm-cli key generate-file --encoding pem --path public_key_cloudhsm.pem --filter "key-reference=$PUBLIC_KEY_REF" > /dev/null 2>&1
+    # # Verify using PEM file and binary signature (RSA signatures don't need DER conversion)
+    # openssl dgst -sha256 -verify public_key_cloudhsm.pem -signature signature.bin message.txt > verification.txt 2>&1
+    # result=$(grep -q "Verified OK" verification.txt && echo "success" || echo "failure")
+    # echo "Verification using PEM of CloudHSM public key: $result"
+
+    # Option 3: Verify using KMS Public Key with retry logic
+    result="failure"
+    max_attempts=5
+    for attempt in $(seq 1 $max_attempts); do
+        echo "Verification attempt $attempt/$max_attempts using KMS public key..."
+        
+        if aws kms verify --key-id $KMS_KEY_ID --message fileb://message.txt --message-type RAW --signing-algorithm RSASSA_PKCS1_V1_5_SHA_256 --signature fileb://signature.bin --output json > verification.txt 2>&1; then
+            result=$(cat verification.txt | jq -r 'if .SignatureValid then "success" else "failure" end')
+            echo "Verification using KMS public key: $result"
+            break
+        else
+            if grep -qi "pending import\|invalid.*state" verification.txt; then
+                echo "Key still not ready for operations, waiting and retrying..."
+                sleep $((attempt * 3))  # Exponential backoff: 3, 6, 9, 12, 15 seconds
+            else
+                echo "Verification failed with error:"
+                cat verification.txt
+                break
+            fi
+        fi
+        
+        if [ $attempt -eq $max_attempts ]; then
+            echo "Max retry attempts reached, verification failed"
+            result="failure"
+        fi
+    done
+
+    # # Option 4: Verify using OpenSSL and PEM file from KMS public key
+    # aws kms get-public-key --key-id $KMS_KEY_ID --query 'PublicKey' --output text | base64 --decode > public_key.der 2>/dev/null
+    # # Convert public key from KMS in DER (binary) format to PEM (Base64-encoded), use OpenSSL for RSA
+    # openssl rsa -pubin -inform DER -in public_key.der -outform PEM -out public_key.pem > /dev/null 2>&1
+    # # Verify using PEM file and binary signature (RSA signatures are already in correct format)
+    # openssl dgst -sha256 -verify public_key.pem -signature signature.bin message.txt > verification.txt 2>&1
+    # result=$(grep -q "Verified OK" verification.txt && echo "success" || echo "failure")
+    # echo "Verification using PEM of KMS public key: $result"
+
+
+    # Step 7: Save results to CSV file
+    if [ "$result" != "success" ]; then
+        echo "FAILED to process CloudHSM key $KEY_REF, $KEY_LABEL" | tee -a $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,"Verification failed: $result" >> $RESULT_FILE_KEYS_FAILED
+    else
+        echo "SUCCEED to process CloudHSM key $KEY_REF, $KEY_LABEL" | tee -a $LOG_FILE
+        echo $KEY_REF,$KEY_LABEL,$KMS_KEY_ID >> $RESULT_FILE_KEYS_SUCCESS
+    fi
+done
+
+# Count results
+SUCCESSFUL_COUNT=0
+FAILED_COUNT=0
+
+if [ -f "$RESULT_FILE_KEYS_SUCCESS" ]; then
+    SUCCESSFUL_COUNT=$(wc -l < "$RESULT_FILE_KEYS_SUCCESS" | tr -d ' ')
+fi
+
+if [ -f "$RESULT_FILE_KEYS_FAILED" ]; then
+    FAILED_COUNT=$(wc -l < "$RESULT_FILE_KEYS_FAILED" | tr -d ' ')
+fi
+
+echo "------ Migration Complete: $SUCCESSFUL_COUNT successful, $FAILED_COUNT failed --------" | tee -a $LOG_FILE
+
+

--- a/security/cloudhsm-to-kms-keys-migration/split-keys-in-json.py
+++ b/security/cloudhsm-to-kms-keys-migration/split-keys-in-json.py
@@ -1,0 +1,137 @@
+
+import json
+import os
+from typing import Dict, List, Any
+from collections import defaultdict
+
+
+def split_json_by_key_type(input_file_path: str, output_dir: str = "split_output", max_keys_per_file: int = 50):
+    """
+    Split a JSON file containing matched keys by key-type, maintaining structure
+    and limiting each output file to max_keys_per_file keys.
+
+    Args:
+        input_file_path (str): Path to the input JSON file
+        output_dir (str): Directory where split files will be saved
+        max_keys_per_file (int): Maximum number of keys per output file (default: 50)
+    """
+
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Read the input JSON file
+    try:
+        with open(input_file_path, 'r', encoding='utf-8') as file:
+            data = json.load(file)
+    except FileNotFoundError:
+        print(f"Error: Input file '{input_file_path}' not found.")
+        return
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON format in input file. {e}")
+        return
+
+    # Extract matched_keys from the data
+    if 'data' not in data or 'matched_keys' not in data['data']:
+        print(
+            "Error: Input JSON doesn't contain the expected structure (data.matched_keys).")
+        return
+
+    matched_keys = data['data']['matched_keys']
+
+    # Group keys by key-type
+    keys_by_type = defaultdict(list)
+
+    for key_entry in matched_keys:
+        # Extract key-type from attributes
+        if 'attributes' in key_entry and 'key-type' in key_entry['attributes']:
+            key_type = key_entry['attributes']['key-type']
+            keys_by_type[key_type].append(key_entry)
+        else:
+            # Handle keys without key-type (put them in 'unknown' category)
+            keys_by_type['unknown'].append(key_entry)
+
+    # Split each key-type group into multiple files if needed
+    file_counter = 0
+    summary = {}
+
+    for key_type, keys in keys_by_type.items():
+        total_keys_for_type = len(keys)
+        files_needed = (total_keys_for_type +
+                        max_keys_per_file - 1) // max_keys_per_file
+
+        summary[key_type] = {
+            'total_keys': total_keys_for_type,
+            'files_created': files_needed
+        }
+
+        for file_index in range(files_needed):
+            # Calculate start and end indices for this chunk
+            start_idx = file_index * max_keys_per_file
+            end_idx = min(start_idx + max_keys_per_file, total_keys_for_type)
+
+            # Get the chunk of keys for this file
+            keys_chunk = keys[start_idx:end_idx]
+
+            # Create the output structure maintaining the original format
+            output_data = {
+                "error_code": data.get("error_code", 0),
+                "data": {
+                    "matched_keys": keys_chunk,
+                    "total_key_count": len(keys_chunk),
+                    "returned_key_count": len(keys_chunk),
+                    "key_type_filter": key_type,
+                    "file_part": file_index + 1,
+                    "total_parts": files_needed,
+                    "original_total_count": data['data'].get('total_key_count', 'unknown')
+                }
+            }
+
+            # Generate output filename
+            if files_needed == 1:
+                output_filename = f"{key_type}_keys.json"
+            else:
+                output_filename = f"{key_type}_keys_part_{file_index + 1:03d}.json"
+
+            output_path = os.path.join(output_dir, output_filename)
+
+            # Write the output file
+            try:
+                with open(output_path, 'w', encoding='utf-8') as output_file:
+                    json.dump(output_data, output_file,
+                              indent=2, ensure_ascii=False)
+
+                file_counter += 1
+                print(f"Created: {output_filename} ({len(keys_chunk)} keys)")
+
+            except Exception as e:
+                print(f"Error writing file '{output_filename}': {e}")
+
+    # Print summary
+    print(f"\n--- Split Summary ---")
+    print(f"Total files created: {file_counter}")
+    print(f"Output directory: {output_dir}")
+    print("\nBreakdown by key-type:")
+    for key_type, info in summary.items():
+        print(
+            f"  {key_type}: {info['total_keys']} keys → {info['files_created']} file(s)")
+
+
+def main():
+    """
+    Example usage of the split function
+    """
+    # Example usage
+    input_file = "private_keys.json"
+    output_directory = "split_keys_output"
+    max_keys = 50
+
+    print(f"Splitting JSON file: {input_file}")
+    print(f"Max keys per file: {max_keys}")
+    print(f"Output directory: {output_directory}")
+    print("-" * 50)
+
+    split_json_by_key_type(input_file, output_directory, max_keys)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a new sample under `security/cloudhsm-to-kms-keys-migration/` that automates bulk migration of asymmetric keys (RSA and ECC) from AWS CloudHSM to AWS KMS, building on the procedure in the AWS Security Blog post [How to migrate asymmetric keys from CloudHSM to AWS KMS](https://aws.amazon.com/blogs/security/how-to-migrate-asymmetric-keys-from-cloudhsm-to-aws-kms/).
- Includes key discovery and listing scripts (with regex filtering), JSON batch splitters/counters for migration planning, type-specific migration scripts (`migrate-cloudhsm-ec-keys-to-kms.sh`, `migrate-cloudhsm-rsa-keys-to-kms.sh`) that perform sign/verify validation, and cleanup utilities.
- Ships with a quick CloudHSM setup guide and a `certs/.gitignore` that prevents accidental commits of customer CA material, private/public key JSON exports, and HSM certificates.

## Test plan
- [ ] Run `generate-cloudhsm-test-keys.sh` against a CloudHSM cluster and confirm test EC key pairs are created
- [ ] Run `list-cloudhsm-keys.sh private-key` and `... public-key` and verify outputs land in the expected JSON files
- [ ] Run `count-cloudhsm-keys-by-regex.sh` and `count-key-types-from-json.py` and verify counts match
- [ ] Run `split-keys-in-json.py` and confirm batches of 50 keys are generated under `split_keys_output/`
- [ ] Migrate an EC key batch via `migrate-cloudhsm-ec-keys-to-kms.sh` and verify sign/verify success in result CSV
- [ ] Migrate an RSA key batch via `migrate-cloudhsm-rsa-keys-to-kms.sh` and verify sign/verify success in result CSV
- [ ] Run `delete-cloudhsm-keys-by-regex.sh` against a test pattern and confirm targeted cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)